### PR TITLE
[Feat] support get flops and params

### DIFF
--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -58,6 +58,8 @@ def main():
 
     input_shape = (1, 3, h, w)
 
+    print('input shape is ', input_shape)
+
     model = init_detector(args.config, device='cpu')  # or device='cuda:0'
 
     flops = FlopCountAnalysis(model, torch.ones(input_shape))

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -1,0 +1,76 @@
+import argparse
+
+import numpy as np
+import torch
+from fvcore.nn import FlopCountAnalysis, flop_count_table
+from mmdet.apis import init_detector
+from mmengine import DictAction
+
+from mmyolo.utils import register_all_modules
+
+register_all_modules()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Train a detector')
+    parser.add_argument('config', help='train config file path')
+    parser.add_argument(
+        '--shape',
+        type=int,
+        nargs='+',
+        default=[640, 640],
+        help='input image size')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
+    parser.add_argument(
+        '--size-divisor',
+        type=int,
+        default=32,
+        help='Pad the input image, the minimum size that is divisible '
+        'by size_divisor, -1 means do not pad the image.')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+
+    args = parse_args()
+
+    if len(args.shape) == 1:
+        h = w = args.shape[0]
+    elif len(args.shape) == 2:
+        h, w = args.shape
+    else:
+        raise ValueError('invalid input shape')
+    # ori_shape = (1, 3, h, w)
+    divisor = args.size_divisor
+    if divisor > 0:
+        h = int(np.ceil(h / divisor)) * divisor
+        w = int(np.ceil(w / divisor)) * divisor
+
+    input_shape = (1, 3, h, w)
+
+    model = init_detector(args.config, device='cpu')  # or device='cuda:0'
+
+    flops = FlopCountAnalysis(model, torch.ones(input_shape))
+
+    # params = parameter_count_table(model)
+    flops_data = flop_count_table(flops)
+
+    print(flops_data)
+
+    print('!!!Please be cautious if you use the results in papers. '
+          'You may need to check if all ops are supported and verify that the '
+          'flops computation is correct.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION


## Motivation

support get flops and params

```shell
python tools/analysis_tools/get_flops.py configs/yolov5/yolov5_l-v61_syncbn_fast_8xb16-300e_coco.py
```

```shell
(mmyolo) ➜  mmyolo git:(get_flops) python tools/analysis_tools/get_flops.py configs/yolov5/yolov5_l-v61_syncbn_fast_8xb16-300e_coco.py
input shape is  (1, 3, 640, 640)
| module                                       | #parameters or shape   | #flops     |
|:---------------------------------------------|:-----------------------|:-----------|
| model                                        | 46.564M                | 54.646G    |
|  backbone                                    |  26.583M               |  34.789G   |
|   backbone.stem                              |   7.04K                |   0.721G   |
|    backbone.stem.conv                        |    6.912K              |    0.708G  |
|    backbone.stem.bn                          |    0.128K              |    13.107M |
|   backbone.stage1                            |   0.231M               |   5.911G   |
|    backbone.stage1.0                         |    73.984K             |    1.894G  |
|    backbone.stage1.1                         |    0.157M              |    4.017G  |
|   backbone.stage2                            |   1.414M               |   9.047G   |
|    backbone.stage2.0                         |    0.295M              |    1.891G  |
|    backbone.stage2.1                         |    1.118M              |    7.157G  |
|   backbone.stage3                            |   7.614M               |   12.183G  |
|    backbone.stage3.0                         |    1.181M              |    1.889G  |
|    backbone.stage3.1                         |    6.434M              |    10.294G |
|   backbone.stage4                            |   17.317M              |   6.927G   |
|    backbone.stage4.0                         |    4.721M              |    1.888G  |
|    backbone.stage4.1                         |    9.972M              |    3.989G  |
|    backbone.stage4.2                         |    2.625M              |    1.05G   |
|  neck                                        |  19.523M               |  19.126G   |
|   neck.reduce_layers.2                       |   0.525M               |   0.21G    |
|    neck.reduce_layers.2.conv                 |    0.524M              |    0.21G   |
|    neck.reduce_layers.2.bn                   |    1.024K              |    0.41M   |
|   neck.top_down_layers                       |   3.58M                |   9.043G   |
|    neck.top_down_layers.0                    |    2.889M              |    4.623G  |
|    neck.top_down_layers.1                    |    0.691M              |    4.42G   |
|   neck.downsample_layers                     |   2.951M               |   1.889G   |
|    neck.downsample_layers.0                  |    0.59M               |    0.945G  |
|    neck.downsample_layers.1                  |    2.36M               |    0.944G  |
|   neck.bottom_up_layers                      |   12.467M              |   7.981G   |
|    neck.bottom_up_layers.0                   |    2.495M              |    3.993G  |
|    neck.bottom_up_layers.1                   |    9.972M              |    3.989G  |
|   neck.upsample_layers                       |                        |   2.458M   |
|    neck.upsample_layers.0                    |                        |    0.819M  |
|    neck.upsample_layers.1                    |                        |    1.638M  |
|  bbox_head.head_module.convs_pred            |  0.458M                |  0.731G    |
|   bbox_head.head_module.convs_pred.0         |   65.535K              |   0.418G   |
|    bbox_head.head_module.convs_pred.0.weight |    (255, 256, 1, 1)    |            |
|    bbox_head.head_module.convs_pred.0.bias   |    (255,)              |            |
|   bbox_head.head_module.convs_pred.1         |   0.131M               |   0.209G   |
|    bbox_head.head_module.convs_pred.1.weight |    (255, 512, 1, 1)    |            |
|    bbox_head.head_module.convs_pred.1.bias   |    (255,)              |            |
|   bbox_head.head_module.convs_pred.2         |   0.261M               |   0.104G   |
|    bbox_head.head_module.convs_pred.2.weight |    (255, 1024, 1, 1)   |            |
|    bbox_head.head_module.convs_pred.2.bias   |    (255,)              |            |
!!!Please be cautious if you use the results in papers. You may need to check if all ops are supported and verify that the flops computation is correct.
```