### PR TITLE
[Feature] Make docker image smaller

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,9 +4,10 @@ ARG CUDNN="8"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
-ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6+PTX"
-ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
-ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
+ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0 7.5 8.0 8.6+PTX" \
+    TORCH_NVCC_FLAGS="-Xfatbin -compress-all" \
+    CMAKE_PREFIX_PATH="$(dirname $(which conda))/../" \
+    FORCE_CUDA="1"
 
 RUN rm /etc/apt/sources.list.d/cuda.list \
     && rm /etc/apt/sources.list.d/nvidia-ml.list \
@@ -15,7 +16,8 @@ RUN rm /etc/apt/sources.list.d/cuda.list \
     && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
 
 # (Optional)
-# RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list
+# RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \
+#    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 
 RUN apt-get update \
     && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
@@ -23,12 +25,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install MMEngine , MMCV and MMDet
-RUN pip install openmim
-RUN mim install  mmengine "mmcv>=2.0.0rc1" "mmdet>=3.0.0rc0"
+RUN pip install --no-cache-dir openmim && \
+    mim install --no-cache-dir mmengine "mmcv>=2.0.0rc1" "mmdet>=3.0.0rc0"
 
 # Install MMYOLO
-RUN conda clean --all
-RUN git clone https://github.com/open-mmlab/mmyolo.git /mmyolo
+RUN git clone https://github.com/open-mmlab/mmyolo.git /mmyolo && \
+    cd /mmyolo && \
+    mim install --no-cache-dir -e .
+
 WORKDIR /mmyolo
-ENV FORCE_CUDA="1"
-RUN mim install -e .

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -214,13 +214,23 @@ Within Jupyter, the exclamation mark `!` is used to call external executables an
 
 We provide a [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) to build an image. Ensure that your [docker version](https://docs.docker.com/engine/install/) >=19.03.
 
+Reminder: If you find out that your download speed is very slow, we suggest that you can canceling the comments in the last two lines of `Optional` in the [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile#L19-L20) to obtain a rocket like download speed:
+
+```dockerfile
+# (Optional)
+RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \
+    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+Build Command：
+
 ```shell
 # build an image with PyTorch 1.9, CUDA 11.1
 # If you prefer other versions, just modified the Dockerfile
 docker build -t mmyolo docker/
 ```
 
-Run it with
+Run it with:
 
 ```shell
 export DATA_DIR=/path/to/your/dataset

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -219,7 +219,8 @@ print(mmyolo.__version__)
 
 我们提供了一个 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) 来构建一个镜像。请确保你的 [docker版本](https://docs.docker.com/engine/install/) >=`19.03`。
 
-温馨提示；国内用户建议取消掉 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) 里面 `Optional` 那两行的注释，可以有火箭一般的下载提速：
+温馨提示；国内用户建议取消掉 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile#L19-L20) 里面 `Optional` 后两行的注释，可以获得火箭一般的下载提速：
+
 ```dockerfile
 # (Optional)
 RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -219,7 +219,7 @@ print(mmyolo.__version__)
 
 我们提供了一个 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) 来构建一个镜像。请确保你的 [docker版本](https://docs.docker.com/engine/install/) >=`19.03`。
 
-温馨提示；国内用户建议取消掉 `Optional` 那两行的注释，可以有火箭一般的下载提速：
+温馨提示；国内用户建议取消掉 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) 里面 `Optional` 那两行的注释，可以有火箭一般的下载提速：
 ```dockerfile
 # (Optional)
 RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -219,6 +219,15 @@ print(mmyolo.__version__)
 
 我们提供了一个 [Dockerfile](https://github.com/open-mmlab/mmyolo/blob/master/docker/Dockerfile) 来构建一个镜像。请确保你的 [docker版本](https://docs.docker.com/engine/install/) >=`19.03`。
 
+温馨提示；国内用户建议取消掉 `Optional` 那两行的注释，可以有火箭一般的下载提速：
+```dockerfile
+# (Optional)
+RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \
+    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+```
+
+构建命令：
+
 ```shell
 # build an image with PyTorch 1.9, CUDA 11.1
 # If you prefer other versions, just modified the Dockerfile


### PR DESCRIPTION
## Motivation

Dockerfile has room for improvement.

## Modification

- Decrease docker layer.
- Make docker image smaller. 

Previous built docker image is **`18.1G`**, after my improve, the size of built docker image decrease to `17.9G`. Which means that except the size of the basic image `17.1G`, the size of image layer we built is **20% less**.

![image](https://user-images.githubusercontent.com/25873202/191538189-10440848-c3ae-4eeb-9443-1a0e298e171c.png)
