### PR TITLE
Out_channels is not used by YOLOv5PAFPN

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -14,7 +14,11 @@ env_cfg = dict(
     dist_cfg=dict(backend='nccl'),
 )
 
-vis_backends = [dict(type='LocalVisBackend')]
+vis_backends = [
+    dict(type='LocalVisBackend'),
+    # dict(type='TensorboardVisBackend')  # tensorboard logger
+]
+
 visualizer = dict(
     type='mmdet.DetLocalVisualizer',
     vis_backends=vis_backends,

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -17,7 +17,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels (used at each scale)
+        out_channels (List[int]): Number of output channels per scale.
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -33,7 +33,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: int,
+                 out_channels: List[int],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  freeze_all: bool = False,

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -117,7 +117,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         if self.freeze_all:
             self._freeze_all()
 
-    def forward(self, inputs: List) -> tuple:
+    def forward(self, inputs: List[torch.Tensor]) -> tuple:
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -117,7 +117,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         if self.freeze_all:
             self._freeze_all()
 
-    def forward(self, inputs: torch.Tensor) -> tuple:
+    def forward(self, inputs: List) -> tuple:
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -18,7 +18,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels (used at each scale)
+        out_channels (int): Number of output channels per scale.
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -35,7 +35,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: int,
+                 out_channels: List[int],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  num_csp_blocks: int = 1,
@@ -101,7 +101,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
             return CSPLayer(
                 make_divisible(self.in_channels[idx - 1] * 2,
                                self.widen_factor),
-                make_divisible(self.in_channels[idx - 1], self.widen_factor),
+                make_divisible(self.out_channels[idx - 1], self.widen_factor),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,
@@ -137,7 +137,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The downsample layer.
         """
         return ConvModule(
-            make_divisible(self.in_channels[idx], self.widen_factor),
+            make_divisible(self.out_channels[idx], self.widen_factor),
             make_divisible(self.in_channels[idx], self.widen_factor),
             kernel_size=3,
             stride=2,
@@ -156,7 +156,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
         """
         return CSPLayer(
             make_divisible(self.in_channels[idx] * 2, self.widen_factor),
-            make_divisible(self.in_channels[idx + 1], self.widen_factor),
+            make_divisible(self.out_channels[idx + 1], self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
             norm_cfg=self.norm_cfg,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation 
English: I want to use swin transformer to replace YOLOv5CSPDarknet in yolov5_m, so I changed in_channnels=[192,384,768], out_channels=[192,384,768] in neck, Change in_channels=[192,384,768] in head_module and set widen_factor to 1. 
 In this case,  an error occurred, so I check the pafpn's source code, I find that out_channels in YOLOv5PAFPN is not used, so I made some changes to the source code to make it work with other backbone，.

Chinese: 我想用swin transformer替换掉yolov5_m中的YOLOv5CSPDarknet，因此我将neck中的out_channels和in_channels设置为了[192, 384, 768]，将head_module中的in_channles设置为了[192, 384, 768]，将所有widen_factor设置为1。在该情况下，会发生报错，我检测了YOLOv5PAFPN的源代码，发现out_channels没有被使用，因此当YOLOv5HeadModule中的in_channels和neck中的in_channels发生变动后，会导致参数不匹配，因此发生报错，为使模型的配置文件更加的灵活，因此做出了部分改动。

## Modification

- make out_channels in YOLOv5CSPDarknet.
- add tensorboard configuration in default_runtime.py
![github_yolov5_pafpn](https://user-images.githubusercontent.com/82379175/191942378-d3f83b7a-4edc-4faa-b54f-8c5a1481a59f.png)


## BC-breaking (Optional)

No，When using the official configuration file, the yolov5 structure remains the same as the original one。



## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
