### PR TITLE
[Fix] Out_channels is not used by YOLOv5PAFPN

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -14,10 +14,7 @@ env_cfg = dict(
     dist_cfg=dict(backend='nccl'),
 )
 
-vis_backends = [
-    dict(type='LocalVisBackend'),
-    # dict(type='TensorboardVisBackend')  # tensorboard logger
-]
+vis_backends = [dict(type='LocalVisBackend')]
 
 visualizer = dict(
     type='mmdet.DetLocalVisualizer',

--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -14,7 +14,11 @@ env_cfg = dict(
     dist_cfg=dict(backend='nccl'),
 )
 
-vis_backends = [dict(type='LocalVisBackend')]
+vis_backends = [
+    dict(type='LocalVisBackend'),
+    # dict(type='TensorboardVisBackend')  # tensorboard logger
+]
+
 visualizer = dict(
     type='mmdet.DetLocalVisualizer',
     vis_backends=vis_backends,

--- a/mmyolo/models/backbones/base_backbone.py
+++ b/mmyolo/models/backbones/base_backbone.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABCMeta, abstractmethod
-from typing import Sequence
+from typing import List, Sequence
 
 import torch
 import torch.nn as nn
@@ -38,7 +38,7 @@ class BaseBackbone(BaseModule, metaclass=ABCMeta):
     """
 
     def __init__(self,
-                 arch_setting: dict,
+                 arch_setting: List[list],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  input_channels: int = 3,

--- a/mmyolo/models/dense_heads/yolov5_head.py
+++ b/mmyolo/models/dense_heads/yolov5_head.py
@@ -48,7 +48,8 @@ class YOLOv5HeadModule(BaseModule):
                  init_cfg: OptMultiConfig = None):
         super().__init__(init_cfg=init_cfg)
         self.num_classes = num_classes
-        in_channels = [in_channels] * len(featmap_strides) if type(in_channels) is int else in_channels
+        in_channels = [in_channels] * len(featmap_strides) \
+            if type(in_channels) is int else in_channels
         self.in_channels = in_channels
         self.widen_factor = widen_factor
 
@@ -59,7 +60,7 @@ class YOLOv5HeadModule(BaseModule):
 
         in_channels = []
         for channel in self.in_channels:
-            channel = make_divisible(channel, self.widen_factor)
+            channel = make_divisible(channel, self.widen_factor, 1)
             in_channels.append(channel)
         self.in_channels = in_channels
 

--- a/mmyolo/models/dense_heads/yolov5_head.py
+++ b/mmyolo/models/dense_heads/yolov5_head.py
@@ -48,6 +48,7 @@ class YOLOv5HeadModule(BaseModule):
                  init_cfg: OptMultiConfig = None):
         super().__init__(init_cfg=init_cfg)
         self.num_classes = num_classes
+        in_channels = [in_channels] * len(featmap_strides) if type(in_channels) is int else in_channels
         self.in_channels = in_channels
         self.widen_factor = widen_factor
 

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABCMeta, abstractmethod
-from typing import List
+from typing import List, Union
 
 import torch
 import torch.nn as nn
@@ -33,7 +33,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: int,
+                 out_channels: Union[int, List],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  freeze_all: bool = False,

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -42,7 +42,8 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
                  init_cfg: OptMultiConfig = None):
         super().__init__(init_cfg)
         self.in_channels = in_channels
-        out_channels = [out_channels] * len(in_channels) if type(out_channels) is int else out_channels
+        out_channels = [out_channels] * len(in_channels) \
+            if type(out_channels) is int else out_channels
         self.out_channels = out_channels
         self.deepen_factor = deepen_factor
         self.widen_factor = widen_factor
@@ -122,13 +123,13 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers
-        reduce_outs = []
+        reduce_outs = [] # top进行了降维，其他Identity, [in_channels[0], in_channels[1], in_channels[1]]
         for idx in range(len(self.in_channels)):
             reduce_outs.append(self.reduce_layers[idx](inputs[idx]))
 
         # top-down path
         inner_outs = [reduce_outs[-1]]
-        for idx in range(len(self.in_channels) - 1, 0, -1):
+        for idx in range(len(self.in_channels) - 1, 0, -1): # 2, 1
             feat_heigh = inner_outs[0]
             feat_low = reduce_outs[idx - 1]
             upsample_feat = self.upsample_layers[len(self.in_channels) - 1 -
@@ -137,7 +138,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
             inner_out = self.top_down_layers[len(self.in_channels) - 1 - idx](
                 torch.cat([upsample_feat, feat_low], 1))
-            inner_outs.insert(0, inner_out)
+            inner_outs.insert(0, inner_out) # [256, 256, 512]
 
         # bottom-up path
         outs = [inner_outs[0]]

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -17,7 +17,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels (used at each scale)
+        out_channels (List[int]): Number of output channels per scale.
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -33,7 +33,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: int,
+                 out_channels: List[int],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  freeze_all: bool = False,

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -33,7 +33,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: List[int],
+                 out_channels: int,
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  freeze_all: bool = False,
@@ -42,6 +42,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
                  init_cfg: OptMultiConfig = None):
         super().__init__(init_cfg)
         self.in_channels = in_channels
+        out_channels = [out_channels] * len(in_channels) if type(out_channels) is int else out_channels
         self.out_channels = out_channels
         self.deepen_factor = deepen_factor
         self.widen_factor = widen_factor

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -117,7 +117,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         if self.freeze_all:
             self._freeze_all()
 
-    def forward(self, inputs: List) -> tuple:
+    def forward(self, inputs: List[torch.Tensor]) -> tuple:
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -123,13 +123,13 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers
-        reduce_outs = [] # top进行了降维，其他Identity, [in_channels[0], in_channels[1], in_channels[1]]
+        reduce_outs = []
         for idx in range(len(self.in_channels)):
             reduce_outs.append(self.reduce_layers[idx](inputs[idx]))
 
         # top-down path
         inner_outs = [reduce_outs[-1]]
-        for idx in range(len(self.in_channels) - 1, 0, -1): # 2, 1
+        for idx in range(len(self.in_channels) - 1, 0, -1):
             feat_heigh = inner_outs[0]
             feat_low = reduce_outs[idx - 1]
             upsample_feat = self.upsample_layers[len(self.in_channels) - 1 -
@@ -138,7 +138,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
             inner_out = self.top_down_layers[len(self.in_channels) - 1 - idx](
                 torch.cat([upsample_feat, feat_low], 1))
-            inner_outs.insert(0, inner_out) # [256, 256, 512]
+            inner_outs.insert(0, inner_out)
 
         # bottom-up path
         outs = [inner_outs[0]]

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -117,7 +117,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
         if self.freeze_all:
             self._freeze_all()
 
-    def forward(self, inputs: torch.Tensor) -> tuple:
+    def forward(self, inputs: List) -> tuple:
         """Forward function."""
         assert len(inputs) == len(self.in_channels)
         # reduce layers

--- a/mmyolo/models/necks/base_yolo_neck.py
+++ b/mmyolo/models/necks/base_yolo_neck.py
@@ -17,7 +17,7 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (List[int]): Number of output channels per scale.
+        out_channels (int): Number of output channels (used at each scale)
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -42,8 +42,6 @@ class BaseYOLONeck(BaseModule, metaclass=ABCMeta):
                  init_cfg: OptMultiConfig = None):
         super().__init__(init_cfg)
         self.in_channels = in_channels
-        out_channels = [out_channels] * len(in_channels) \
-            if type(out_channels) is int else out_channels
         self.out_channels = out_channels
         self.deepen_factor = deepen_factor
         self.widen_factor = widen_factor

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -74,8 +74,10 @@ class YOLOv5PAFPN(BaseYOLONeck):
         """
         if idx == 2:
             layer = ConvModule(
-                make_divisible(self.in_channels[idx], self.widen_factor),
-                make_divisible(self.in_channels[idx - 1], self.widen_factor),
+                make_divisible(self.in_channels[idx],
+                               self.widen_factor, 1),
+                make_divisible(self.in_channels[idx - 1],
+                               self.widen_factor, 1),
                 1,
                 norm_cfg=self.norm_cfg,
                 act_cfg=self.act_cfg)
@@ -100,8 +102,9 @@ class YOLOv5PAFPN(BaseYOLONeck):
         if idx == 1:
             return CSPLayer(
                 make_divisible(self.in_channels[idx - 1] * 2,
-                               self.widen_factor),
-                make_divisible(self.out_channels[idx - 1], self.widen_factor),
+                               self.widen_factor, 1),
+                make_divisible(self.out_channels[idx - 1],
+                               self.widen_factor, 1),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,
@@ -110,9 +113,9 @@ class YOLOv5PAFPN(BaseYOLONeck):
             return nn.Sequential(
                 CSPLayer(
                     make_divisible(self.in_channels[idx - 1] * 2,
-                                   self.widen_factor),
+                                   self.widen_factor, 1),
                     make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor),
+                                   self.widen_factor, 1),
                     num_blocks=make_round(self.num_csp_blocks,
                                           self.deepen_factor),
                     add_identity=False,
@@ -120,9 +123,9 @@ class YOLOv5PAFPN(BaseYOLONeck):
                     act_cfg=self.act_cfg),
                 ConvModule(
                     make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor),
+                                   self.widen_factor, 1),
                     make_divisible(self.in_channels[idx - 2],
-                                   self.widen_factor),
+                                   self.widen_factor, 1),
                     kernel_size=1,
                     norm_cfg=self.norm_cfg,
                     act_cfg=self.act_cfg))
@@ -137,8 +140,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The downsample layer.
         """
         return ConvModule(
-            make_divisible(self.out_channels[idx], self.widen_factor),
-            make_divisible(self.in_channels[idx], self.widen_factor),
+            make_divisible(self.out_channels[idx], self.widen_factor, 1),
+            make_divisible(self.in_channels[idx], self.widen_factor, 1),
             kernel_size=3,
             stride=2,
             padding=1,
@@ -155,8 +158,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The bottom up layer.
         """
         return CSPLayer(
-            make_divisible(self.in_channels[idx] * 2, self.widen_factor),
-            make_divisible(self.out_channels[idx + 1], self.widen_factor),
+            make_divisible(self.in_channels[idx] * 2, self.widen_factor, 1),
+            make_divisible(self.out_channels[idx + 1], self.widen_factor, 1),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
             norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -18,7 +18,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels per scale.
+        out_channels (int): Number of output channels (used at each scale)
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -35,7 +35,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: List[int],
+                 out_channels: int,
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  num_csp_blocks: int = 1,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -102,10 +102,12 @@ class YOLOv5PAFPN(BaseYOLONeck):
         """
         if idx == 1:
             return CSPLayer(
-                make_divisible(self.in_channels[idx - 1] * 2,
-                               self.widen_factor, divisor=1),
-                make_divisible(self.out_channels[idx - 1], self.widen_factor,
-                               divisor=1),
+                make_divisible(
+                    self.in_channels[idx - 1] * 2,
+                    self.widen_factor,
+                    divisor=1),
+                make_divisible(
+                    self.out_channels[idx - 1], self.widen_factor, divisor=1),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,
@@ -115,16 +117,20 @@ class YOLOv5PAFPN(BaseYOLONeck):
                 CSPLayer(
                     make_divisible(self.in_channels[idx - 1] * 2,
                                    self.widen_factor, 1),
-                    make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor, divisor=1),
+                    make_divisible(
+                        self.in_channels[idx - 1],
+                        self.widen_factor,
+                        divisor=1),
                     num_blocks=make_round(self.num_csp_blocks,
                                           self.deepen_factor),
                     add_identity=False,
                     norm_cfg=self.norm_cfg,
                     act_cfg=self.act_cfg),
                 ConvModule(
-                    make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor, divisor=1),
+                    make_divisible(
+                        self.in_channels[idx - 1],
+                        self.widen_factor,
+                        divisor=1),
                     make_divisible(self.in_channels[idx - 2],
                                    self.widen_factor, 1),
                     kernel_size=1,
@@ -159,8 +165,10 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The bottom up layer.
         """
         return CSPLayer(
-            make_divisible(self.in_channels[idx] * 2, self.widen_factor, divisor=1),
-            make_divisible(self.out_channels[idx + 1], self.widen_factor, divisor=1),
+            make_divisible(
+                self.in_channels[idx] * 2, self.widen_factor, divisor=1),
+            make_divisible(
+                self.out_channels[idx + 1], self.widen_factor, divisor=1),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
             norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -116,7 +116,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
                     make_divisible(self.in_channels[idx - 1] * 2,
                                    self.widen_factor, 1),
                     make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor, 1),
+                                   self.widen_factor, divisor=1),
                     num_blocks=make_round(self.num_csp_blocks,
                                           self.deepen_factor),
                     add_identity=False,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -18,7 +18,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     Args:
         in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels (used at each scale)
+        out_channels (int): Number of output channels per scale.
         deepen_factor (float): Depth multiplier, multiply number of
             blocks in CSP layer by this amount. Defaults to 1.0.
         widen_factor (float): Width multiplier, multiply number of
@@ -35,7 +35,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
     def __init__(self,
                  in_channels: List[int],
-                 out_channels: int,
+                 out_channels: List[int],
                  deepen_factor: float = 1.0,
                  widen_factor: float = 1.0,
                  num_csp_blocks: int = 1,
@@ -101,7 +101,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
             return CSPLayer(
                 make_divisible(self.in_channels[idx - 1] * 2,
                                self.widen_factor),
-                make_divisible(self.in_channels[idx - 1], self.widen_factor),
+                make_divisible(self.out_channels[idx - 1], self.widen_factor),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,
@@ -137,7 +137,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The downsample layer.
         """
         return ConvModule(
-            make_divisible(self.in_channels[idx], self.widen_factor),
+            make_divisible(self.out_channels[idx], self.widen_factor),
             make_divisible(self.in_channels[idx], self.widen_factor),
             kernel_size=3,
             stride=2,
@@ -156,7 +156,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
         """
         return CSPLayer(
             make_divisible(self.in_channels[idx] * 2, self.widen_factor),
-            make_divisible(self.in_channels[idx + 1], self.widen_factor),
+            make_divisible(self.out_channels[idx + 1], self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
             norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -159,8 +159,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The bottom up layer.
         """
         return CSPLayer(
-            make_divisible(self.in_channels[idx] * 2, self.widen_factor, 1),
-            make_divisible(self.out_channels[idx + 1], self.widen_factor, 1),
+            make_divisible(self.in_channels[idx] * 2, self.widen_factor, divisor=1),
+            make_divisible(self.out_channels[idx + 1], self.widen_factor, divisor=1),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
             norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -45,6 +45,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
                  act_cfg: ConfigType = dict(type='SiLU', inplace=True),
                  init_cfg: OptMultiConfig = None):
         self.num_csp_blocks = num_csp_blocks
+        out_channels = [out_channels] * len(in_channels) \
+            if type(out_channels) is int else out_channels
         super().__init__(
             in_channels=in_channels,
             out_channels=out_channels,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -103,9 +103,9 @@ class YOLOv5PAFPN(BaseYOLONeck):
         if idx == 1:
             return CSPLayer(
                 make_divisible(self.in_channels[idx - 1] * 2,
-                               self.widen_factor, 1),
+                               self.widen_factor, divisor=1),
                 make_divisible(self.out_channels[idx - 1], self.widen_factor,
-                               1),
+                               divisor=1),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -74,10 +74,9 @@ class YOLOv5PAFPN(BaseYOLONeck):
         """
         if idx == 2:
             layer = ConvModule(
-                make_divisible(self.in_channels[idx],
-                               self.widen_factor, 1),
-                make_divisible(self.in_channels[idx - 1],
-                               self.widen_factor, 1),
+                make_divisible(self.in_channels[idx], self.widen_factor, 1),
+                make_divisible(self.in_channels[idx - 1], self.widen_factor,
+                               1),
                 1,
                 norm_cfg=self.norm_cfg,
                 act_cfg=self.act_cfg)
@@ -103,8 +102,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
             return CSPLayer(
                 make_divisible(self.in_channels[idx - 1] * 2,
                                self.widen_factor, 1),
-                make_divisible(self.out_channels[idx - 1],
-                               self.widen_factor, 1),
+                make_divisible(self.out_channels[idx - 1], self.widen_factor,
+                               1),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
                 norm_cfg=self.norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -124,7 +124,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
                     act_cfg=self.act_cfg),
                 ConvModule(
                     make_divisible(self.in_channels[idx - 1],
-                                   self.widen_factor, 1),
+                                   self.widen_factor, divisor=1),
                     make_divisible(self.in_channels[idx - 2],
                                    self.widen_factor, 1),
                     kernel_size=1,

--- a/tests/test_models/test_dense_heads/test_yolov5_head.py
+++ b/tests/test_models/test_dense_heads/test_yolov5_head.py
@@ -145,10 +145,3 @@ class TestYOLOv5Head(TestCase):
                            'obj loss should be non-zero')
 
 
-if __name__ == '__main__':
-    for e in range(99):
-        test_model = TestYOLOv5Head()
-        test_model.setUp()
-        test_model.test_predict_by_feat()
-        test_model.test_loss_by_feat()
-        print(f'测试{e}通过')

--- a/tests/test_models/test_dense_heads/test_yolov5_head.py
+++ b/tests/test_models/test_dense_heads/test_yolov5_head.py
@@ -143,5 +143,3 @@ class TestYOLOv5Head(TestCase):
                            'box loss should be non-zero')
         self.assertGreater(onegt_obj_loss.item(), 0,
                            'obj loss should be non-zero')
-
-

--- a/tests/test_models/test_dense_heads/test_yolov5_head.py
+++ b/tests/test_models/test_dense_heads/test_yolov5_head.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from random import randint
 from unittest import TestCase
 
 import torch
@@ -17,7 +18,9 @@ class TestYOLOv5Head(TestCase):
         self.head_module = dict(
             type='YOLOv5HeadModule',
             num_classes=2,
-            in_channels=[32, 64, 128],
+            in_channels=[randint(88, 999),
+                         randint(88, 999),
+                         randint(88, 999)],
             featmap_strides=[8, 16, 32],
             num_base_priors=3)
 
@@ -140,3 +143,12 @@ class TestYOLOv5Head(TestCase):
                            'box loss should be non-zero')
         self.assertGreater(onegt_obj_loss.item(), 0,
                            'obj loss should be non-zero')
+
+
+if __name__ == '__main__':
+    for e in range(99):
+        test_model = TestYOLOv5Head()
+        test_model.setUp()
+        test_model.test_predict_by_feat()
+        test_model.test_loss_by_feat()
+        print(f'测试{e}通过')

--- a/tests/test_models/test_necks/test_yolov5_pafpn.py
+++ b/tests/test_models/test_necks/test_yolov5_pafpn.py
@@ -29,8 +29,3 @@ class TestYOLOv5PAFPN(TestCase):
             for i in range(len(feats)):
                 assert outs[i].shape[1] == out_channels[i]
                 assert outs[i].shape[2] == outs[i].shape[3] == s // (2**i)
-            print(f'测试{e}通过')
-
-
-if __name__ == '__main__':
-    TestYOLOv5PAFPN().test_forward()

--- a/tests/test_models/test_necks/test_yolov5_pafpn.py
+++ b/tests/test_models/test_necks/test_yolov5_pafpn.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from random import randint
 from unittest import TestCase
 
 import torch
@@ -13,16 +14,23 @@ class TestYOLOv5PAFPN(TestCase):
 
     def test_forward(self):
         s = 64
-        in_channels = [8, 16, 32]
-        feat_sizes = [s // 2**i for i in range(4)]  # [32, 16, 8]
-        out_channels = [8, 16, 32]
-        feats = [
-            torch.rand(1, in_channels[i], feat_sizes[i], feat_sizes[i])
-            for i in range(len(in_channels))
-        ]
-        neck = YOLOv5PAFPN(in_channels=in_channels, out_channels=out_channels)
-        outs = neck(feats)
-        assert len(outs) == len(feats)
-        for i in range(len(feats)):
-            assert outs[i].shape[1] == out_channels[i]
-            assert outs[i].shape[2] == outs[i].shape[3] == s // (2**i)
+        for e in range(99):
+            in_channels = [randint(7, 999), randint(7, 999), randint(7, 999)]
+            feat_sizes = [s // 2**i for i in range(4)]  # [32, 16, 8]
+            out_channels = [randint(7, 999), randint(7, 999), randint(7, 999)]
+            feats = [
+                torch.rand(1, in_channels[i], feat_sizes[i], feat_sizes[i])
+                for i in range(len(in_channels))
+            ]
+            neck = YOLOv5PAFPN(
+                in_channels=in_channels, out_channels=out_channels)
+            outs = neck(feats)
+            assert len(outs) == len(feats)
+            for i in range(len(feats)):
+                assert outs[i].shape[1] == out_channels[i]
+                assert outs[i].shape[2] == outs[i].shape[3] == s // (2**i)
+            print(f'测试{e}通过')
+
+
+if __name__ == '__main__':
+    TestYOLOv5PAFPN().test_forward()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

English: I want to use swin transformer to replace YOLOv5CSPDarknet in yolov5_m, so I changed in_channnels=[192,384,768], out_channels=[192,384,768] in neck, Change in_channels=[192,384,768] in head_module and set widen_factor to 1.In this case, an error occurred, so I check the pafpn's source code, I find that out_channels in YOLOv5PAFPN is not used, so I made some changes to the source code to make it work with other backbone，.

Chinese: 我想用swin transformer替换掉yolov5_m中的YOLOv5CSPDarknet，因此我将neck中的out_channels和in_channels设置为了[192, 384, 768]，将head_module中的in_channles设置为了[192, 384, 768]，将所有widen_factor设置为1。在该情况下，会发生报错，我检测了YOLOv5PAFPN的源代码，发现out_channels没有被使用，因此当YOLOv5HeadModule中的in_channels和neck中的in_channels发生变动后，会导致参数不匹配，因此发生报错，为使模型的配置文件更加的灵活，因此做出了部分改动。

## Modification

- make out_channels in YOLOv5CSPDarknet.

- add tensorboard configuration in default_runtime.py
As shown in the figure below, the revisions are marked in red letters(修改的部分用红色字做出了标注)
![github_yolov5_pafpn](https://user-images.githubusercontent.com/82379175/191945465-5be5824b-cc90-4764-941e-7596cbd630f2.png)


## BC-breaking (Optional)

No，When using the official configuration file, the yolov5 structure remains the same as the original one。


## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
