### PR TITLE
[Doc][Readme]Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 [![issue resolution](https://isitmaintained.com/badge/resolution/open-mmlab/mmyolo.svg)](https://github.com/open-mmlab/mmyolo/issues)
 
 [📘Documentation](https://mmyolo.readthedocs.io/en/latest/) |
-[🛠️Installation](https://mmyolo.readthedocs.io/en/latest/install.html) |
+[🛠️Installation](https://mmyolo.readthedocs.io/en/latest/get_started.html) |
 [👀Model Zoo](https://mmyolo.readthedocs.io/en/latest/model_zoo.html) |
 [🆕Update News](https://mmyolo.readthedocs.io/en/latest/notes/changelog.html) |
 [🤔Reporting Issues](https://github.com/open-mmlab/mmyolo/issues/new/choose)

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -27,7 +27,7 @@
 [![issue resolution](https://isitmaintained.com/badge/resolution/open-mmlab/mmyolo.svg)](https://github.com/open-mmlab/mmyolo/issues)
 
 [📘使用文档](https://mmyolo.readthedocs.io/zh_CN/latest/) |
-[🛠️安装教程](https://mmyolo.readthedocs.io/zh_CN/latest/install.html) |
+[🛠️安装教程](https://mmyolo.readthedocs.io/zh_CN/latest/get_started.html) |
 [👀模型库](https://mmyolo.readthedocs.io/zh_CN/latest/model_zoo.html) |
 [🆕更新日志](https://mmyolo.readthedocs.io/en/latest/notes/changelog.html) |
 [🤔报告问题](https://github.com/open-mmlab/mmyolo/issues/new/choose)


### PR DESCRIPTION
Modify the installation address in readme. Because there is no special install page in readthedocs, I think the redirect address of install should be get_ started.
