### PR TITLE
Upgrade pre commit hooks 

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   lint:
     docker:
-      - image: cimg/python:3.7.4
+      - image: cimg/python:3.8.14
     steps:
       - checkout
       - run:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -10,7 +10,7 @@ parameters:
 jobs:
   lint:
     docker:
-      - image: cimg/python:3.8.14
+      - image: cimg/python:3.7.4
     steps:
       - checkout
       - run:

--- a/.pre-commit-config-zh-cn.yaml
+++ b/.pre-commit-config-zh-cn.yaml
@@ -48,13 +48,13 @@ repos:
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
-  - repo: https://gitee.com/openmmlab/pre-commit-hooks
+  - repo: https://github.com/open-mmlab/pre-commit-hooks
     rev: v0.2.0
     hooks:
       - id: check-copyright
-        args: ["mmyolo"]
-  - repo: https://gitee.com/openmmlab/mirrors-mypy
-    rev: v0.812
-    hooks:
-      - id: mypy
-        exclude: "docs"
+        args: ["mmyolo", "tests"]
+#  - repo: https://gitee.com/openmmlab/mirrors-mypy
+#    rev: v0.812
+#    hooks:
+#      - id: mypy
+#        exclude: "docs"

--- a/.pre-commit-config-zh-cn.yaml
+++ b/.pre-commit-config-zh-cn.yaml
@@ -1,18 +1,18 @@
 exclude: ^tests/data/
 repos:
-  - repo: https://github.com/PyCQA/flake8
+  - repo: https://gitee.com/openmmlab/mirrors-flake8
     rev: 5.0.4
     hooks:
       - id: flake8
-  - repo: https://github.com/PyCQA/isort
+  - repo: https://gitee.com/openmmlab/mirrors-isort
     rev: 5.10.1
     hooks:
       - id: isort
-  - repo: https://github.com/pre-commit/mirrors-yapf
+  - repo: https://gitee.com/openmmlab/mirrors-yapf
     rev: v0.32.0
     hooks:
       - id: yapf
-  - repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://gitee.com/openmmlab/mirrors-pre-commit-hooks
     rev: v4.3.0
     hooks:
       - id: trailing-whitespace
@@ -25,7 +25,7 @@ repos:
         args: ["--remove"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://github.com/executablebooks/mdformat
+  - repo: https://gitee.com/openmmlab/mirrors-mdformat
     rev: 0.7.9
     hooks:
       - id: mdformat
@@ -34,28 +34,27 @@ repos:
           - mdformat-openmmlab
           - mdformat_frontmatter
           - linkify-it-py
-  - repo: https://github.com/codespell-project/codespell
+  - repo: https://gitee.com/openmmlab/mirrors-codespell
     rev: v2.2.1
     hooks:
       - id: codespell
-  - repo: https://github.com/myint/docformatter
+  - repo: https://gitee.com/openmmlab/mirrors-docformatter
     rev: v1.3.1
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]
-  - repo: https://github.com/asottile/pyupgrade
+  - repo: https://gitee.com/openmmlab/mirrors-pyupgrade
     rev: v3.0.0
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
-  - repo: https://github.com/open-mmlab/pre-commit-hooks
+  - repo: https://gitee.com/openmmlab/pre-commit-hooks
     rev: v0.2.0
     hooks:
       - id: check-copyright
-#        args: ["mmyolo", "tests"]
         args: ["mmyolo"]
-#  - repo: https://github.com/pre-commit/mirrors-mypy
-#    rev: v0.812
-#    hooks:
-#      - id: mypy
-#        exclude: "docs"
+  - repo: https://gitee.com/openmmlab/mirrors-mypy
+    rev: v0.812
+    hooks:
+      - id: mypy
+        exclude: "docs"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,8 +52,7 @@ repos:
     rev: v0.2.0
     hooks:
       - id: check-copyright
-#        args: ["mmyolo", "tests"]
-        args: ["mmyolo"]
+        args: ["mmyolo", "tests"]
 #  - repo: https://github.com/pre-commit/mirrors-mypy
 #    rev: v0.812
 #    hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba, warmup

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba, warmup
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,elease

--- a/tests/test_datasets/__init__.py
+++ b/tests/test_datasets/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_datasets/test_transforms/__init__.py
+++ b/tests/test_datasets/test_transforms/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_engine/__init__.py
+++ b/tests/test_engine/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_engine/test_optimizers/__init__.py
+++ b/tests/test_engine/test_optimizers/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/__init__.py
+++ b/tests/test_models/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_backbone/__init__.py
+++ b/tests/test_models/test_backbone/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_data_preprocessor/__init__.py
+++ b/tests/test_models/test_data_preprocessor/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_dense_heads/__init__.py
+++ b/tests/test_models/test_dense_heads/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_layers/__init__.py
+++ b/tests/test_models/test_layers/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_necks/__init__.py
+++ b/tests/test_models/test_necks/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_task_modules/test_coders/__init__.py
+++ b/tests/test_models/test_task_modules/test_coders/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_utils/__init__.py
+++ b/tests/test_models/test_utils/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_models/test_utils/test_misc.py
+++ b/tests/test_models/test_utils/test_misc.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/tests/test_utils/test_setup_env.py
+++ b/tests/test_utils/test_setup_env.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import datetime
 import sys
 from unittest import TestCase


### PR DESCRIPTION
## Motivation

The motivation to upgrade some versions of pre-commit hooks to latest is that `importlib-metadata v5.0.0` which removed deprecated endpoint breaks the flake8. More details at https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean/73932581#73932581.

<img width="1401" alt="企业微信20221008-114247@2x" src="https://user-images.githubusercontent.com/84259897/194686528-c0448216-9074-492f-b152-1e88402f992e.png">

Refer to https://github.com/open-mmlab/mmengine/pull/576

## Modification

Upgrade some versions of pre-commit hooks.



