### PR TITLE
[Feature] Add save predict info to json file in image demo

### DIFF
--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -24,11 +24,13 @@ def parse_args():
     parser.add_argument('config', help='Config file')
     parser.add_argument('checkpoint', help='Checkpoint file')
     parser.add_argument(
-        '--save-json-type', default='', choices=['cwh', 'tl-wh', 'tl-br'],
+        '--save-json-type',
+        default='',
+        choices=['cwh', 'tl-wh', 'tl-br'],
         help='Save predict info to json with type in ("cwh", "tl-wh", "tl-br"). '
-             '`cwh`: center xy and bbox wh, '
-             '`tl-wh`: top-left xy and bbox wh, '
-             '`tl-br`: top-left xy and bottom-right xy.')
+        '`cwh`: center xy and bbox wh, '
+        '`tl-wh`: top-left xy and bbox wh, '
+        '`tl-br`: top-left xy and bottom-right xy.')
     parser.add_argument(
         '--device', default='cuda:0', help='Device used for inference')
     parser.add_argument(
@@ -125,10 +127,15 @@ def main():
                     # top-left xy and bottom-right xy
                     bbox_save = result.pred_instances['bboxes'][idx].tolist()
 
-                pred_json.append({'image_id': os.path.splitext(filename)[0],
-                                  'category_id': int(result.pred_instances['labels'][idx]),
-                                  'bbox': [round(x, 3) for x in bbox_save],
-                                  'score': round(result.pred_instances['scores'][idx].tolist(), 5)})
+                pred_json.append({
+                    'image_id':
+                    os.path.splitext(filename)[0],
+                    'category_id':
+                    int(result.pred_instances['labels'][idx]),
+                    'bbox': [round(x, 3) for x in bbox_save],
+                    'score':
+                    round(result.pred_instances['scores'][idx].tolist(), 5)
+                })
 
         progress_bar.update()
 
@@ -138,7 +145,8 @@ def main():
             json.dump(pred_json, f)
 
     if not args.show:
-        print_log(f'\nResults have been saved at {os.path.abspath(args.out_dir)}')
+        print_log(
+            f'\nResults have been saved at {os.path.abspath(args.out_dir)}')
 
 
 if __name__ == '__main__':

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -107,14 +107,20 @@ python demo/image_demo.py demo/demo.jpg \
 ```
 Optional parameters:
 - `--out-dir`: The detection results are output to the specified directory. When args have action `--show`, the script do not save results. Default is `./output`. 
+- `--device`: The computing resources used, including cuda and cpu. Default is `cuda:0`.
+- `--show` : Display the results on the screen. Default is `False`.
+- `--score-thr`: Confidence threshold. Default is `0.3`.
 - `--save-json-type'`: Save predict info to json with type in ("cwh", "tl-wh", "tl-br"). File will be saved with file named `predict.json` under `--out-dir`. When args have action `--show`, the script do not save results. Default not saving json file. 
   - `cwh`: BBox center xy and bbox wh.
   - `tl-wh`: Bbox top-left xy and bbox wh.
   - `tl-br`: Bbox top-left xy and bottom-right xy.
-- `--device`: The computing resources used, including cuda and cpu. Default is `cuda:0`.
-- `--show` : Display the results on the screen. Default is `False`.
-- `--score-thr`: Confidence threshold. Default is `0.3`.
 
+  Json file example:
+  ```json
+  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104}, 
+  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942}, 
+  {"image_id": "image2", "category_id": 0, "bbox": [1026.099, 45.593, 39.551, 40.855], "score": 0.61739}, ...]
+  ```
 
 You will see a new image on your `output` folder, where bounding boxes are plotted.
 

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -103,12 +103,18 @@ python demo/image_demo.py demo/demo.jpg \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth
 
-# Optional parameters
-# --out-dir ./output *The detection results are output to the specified directory. When args have action --show, the script do not save results. Default: ./output
-# --device cuda:0    *The computing resources used, including cuda and cpu. Default: cuda:0
-# --show             *Display the results on the screen. Default: False
-# --score-thr 0.3    *Confidence threshold. Default: 0.3
+
 ```
+Optional parameters:
+- `--out-dir`: The detection results are output to the specified directory. When args have action `--show`, the script do not save results. Default is `./output`. 
+- `--save-json-type'`: Save predict info to json with type in ("cwh", "tl-wh", "tl-br"). File will be saved with file named `predict.json` under `--out-dir`. When args have action `--show`, the script do not save results. Default not saving json file. 
+  - `cwh`: BBox center xy and bbox wh.
+  - `tl-wh`: Bbox top-left xy and bbox wh.
+  - `tl-br`: Bbox top-left xy and bottom-right xy.
+- `--device`: The computing resources used, including cuda and cpu. Default is `cuda:0`.
+- `--show` : Display the results on the screen. Default is `False`.
+- `--score-thr`: Confidence threshold. Default is `0.3`.
+
 
 You will see a new image on your `output` folder, where bounding boxes are plotted.
 

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -102,23 +102,29 @@ Option (a). If you install MMYOLO from source, just run the following command.
 python demo/image_demo.py demo/demo.jpg \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth
-
-
 ```
+
 Optional parameters:
-- `--out-dir`: The detection results are output to the specified directory. When args have action `--show`, the script do not save results. Default is `./output`. 
+
+- `--out-dir`: The detection results are output to the specified directory. When args have action `--show`, the script do not save results. Default is `./output`.
+
 - `--device`: The computing resources used, including cuda and cpu. Default is `cuda:0`.
+
 - `--show` : Display the results on the screen. Default is `False`.
+
 - `--score-thr`: Confidence threshold. Default is `0.3`.
-- `--save-json-type'`: Save predict info to json with type in ("cwh", "tl-wh", "tl-br"). File will be saved with file named `predict.json` under `--out-dir`. When args have action `--show`, the script do not save results. Default not saving json file. 
+
+- `--save-json-type'`: Save predict info to json with type in ("cwh", "tl-wh", "tl-br"). File will be saved with file named `predict.json` under `--out-dir`. When args have action `--show`, the script do not save results. Default not saving json file.
+
   - `cwh`: BBox center xy and bbox wh.
   - `tl-wh`: Bbox top-left xy and bbox wh.
   - `tl-br`: Bbox top-left xy and bottom-right xy.
 
   Json file example:
+
   ```json
-  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104}, 
-  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942}, 
+  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104},
+  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942},
   {"image_id": "image2", "category_id": 0, "bbox": [1026.099, 45.593, 39.551, 40.855], "score": 0.61739}, ...]
   ```
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -101,13 +101,17 @@ mim download mmyolo --config yolov5_s-v61_syncbn_fast_8xb16-300e_coco --dest .
 python demo/image_demo.py demo/demo.jpg \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py \
                           yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth
-
-# 可选参数
-# --out-dir ./output *检测结果输出到指定目录下，默认为./output, 当--show参数存在时，不保存检测结果
-# --device cuda:0    *使用的计算资源，包括cuda, cpu等，默认为cuda:0
-# --show             *使用该参数表示在屏幕上显示检测结果，默认为False
-# --score-thr 0.3    *置信度阈值，默认为0.3
 ```
+
+可选参数:
+`--out-dir`：检测结果输出到指定目录下，默认为./output, 当 `--show` 参数存在时，不保存检测结果。默认是 `./output`。
+- `--save-json-type'`: 保存推理结果到 Json 文件，可选格式为 `cwh`、`tl-wh` 和 `tl-br`，保存结果在 `--out-dir` 文件夹下的 `predict.json`。当 `--show` 参数存在时，不保存检测结果。默认不保存。
+  - `cwh`: BBox 中心点 xy 和 bbox wh.
+  - `tl-wh`: BBox top-left xy 和 bbox wh.
+  - `tl-br`: top-left xy 和 bottom-right xy.
+`--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
+`--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
+`--score-thr`：置信度阈值，默认为 `0.3`。
 
 运行结束后，在 `output` 文件夹中可以看到检测结果图像，图像中包含有网络预测的检测框。
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -105,13 +105,20 @@ python demo/image_demo.py demo/demo.jpg \
 
 可选参数:
 `--out-dir`：检测结果输出到指定目录下，默认为./output, 当 `--show` 参数存在时，不保存检测结果。默认是 `./output`。
+`--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
+`--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
+`--score-thr`：置信度阈值，默认为 `0.3`。
 - `--save-json-type'`: 保存推理结果到 Json 文件，可选格式为 `cwh`、`tl-wh` 和 `tl-br`，保存结果在 `--out-dir` 文件夹下的 `predict.json`。当 `--show` 参数存在时，不保存检测结果。默认不保存。
   - `cwh`: BBox 中心点 xy 和 bbox wh.
   - `tl-wh`: BBox top-left xy 和 bbox wh.
   - `tl-br`: top-left xy 和 bottom-right xy.
-`--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
-`--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
-`--score-thr`：置信度阈值，默认为 `0.3`。
+
+  Json 保存结果例子:
+  ```json
+  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104}, 
+  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942}, 
+  {"image_id": "image2", "category_id": 0, "bbox": [1026.099, 45.593, 39.551, 40.855], "score": 0.61739}, ...]
+  ```
 
 运行结束后，在 `output` 文件夹中可以看到检测结果图像，图像中包含有网络预测的检测框。
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -108,15 +108,18 @@ python demo/image_demo.py demo/demo.jpg \
 `--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
 `--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
 `--score-thr`：置信度阈值，默认为 `0.3`。
+
 - `--save-json-type'`: 保存推理结果到 Json 文件，可选格式为 `cwh`、`tl-wh` 和 `tl-br`，保存结果在 `--out-dir` 文件夹下的 `predict.json`。当 `--show` 参数存在时，不保存检测结果。默认不保存。
+
   - `cwh`: BBox 中心点 xy 和 bbox wh.
   - `tl-wh`: BBox top-left xy 和 bbox wh.
   - `tl-br`: top-left xy 和 bottom-right xy.
 
   Json 保存结果例子:
+
   ```json
-  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104}, 
-  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942}, 
+  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104},
+  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942},
   {"image_id": "image2", "category_id": 0, "bbox": [1026.099, 45.593, 39.551, 40.855], "score": 0.61739}, ...]
   ```
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -104,10 +104,14 @@ python demo/image_demo.py demo/demo.jpg \
 ```
 
 可选参数:
-`--out-dir`：检测结果输出到指定目录下，默认为./output, 当 `--show` 参数存在时，不保存检测结果。默认是 `./output`。
-`--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
-`--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
-`--score-thr`：置信度阈值，默认为 `0.3`。
+
+- `--out-dir`：检测结果输出到指定目录下，默认为./output, 当 `--show` 参数存在时，不保存检测结果。默认是 `./output`。
+
+- `--device`：使用的计算资源，包括cuda, cpu等，默认为 `cuda:0`。
+
+- `--show`：使用该参数表示在屏幕上显示检测结果，默认为 `False`。
+
+- `--score-thr`：置信度阈值，默认为 `0.3`。
 
 - `--save-json-type'`: 保存推理结果到 Json 文件，可选格式为 `cwh`、`tl-wh` 和 `tl-br`，保存结果在 `--out-dir` 文件夹下的 `predict.json`。当 `--show` 参数存在时，不保存检测结果。默认不保存。
 


### PR DESCRIPTION
## Motivation

Add save predict info to json file in image demo

## Modification

- `demo/image_demo.py`
- `docs/en/get_started.md`
- `docs/zh_cn/get_started.md`

## Usage 

```shell
python demo/image_demo.py demo/demo.jpg \
                          yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py \
                          yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth \
                          --save-json-type tl-wh
```

Json file example:
```json
  [{"image_id": "image1", "category_id": 0, "bbox": [685.527, 1505.345, 55.327, 54.691], "score": 0.64104}, 
  {"image_id": "image1", "category_id": 1, "bbox": [2127.666, 1416.52, 134.104, 117.782], "score": 0.70942}, 
  {"image_id": "image2", "category_id": 0, "bbox": [1026.099, 45.593, 39.551, 40.855], "score": 0.61739}, ...]
```