### PR TITLE
[Feature] Add `extract_subcoco` script

### DIFF
--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -183,3 +183,32 @@ python tools/model_converters/yolox_to_mmyolo.py --src yolox_s.pth --dst mmyolox
 ```
 
 The converted `mmyolox.pt` can be used by MMYOLO.
+
+## Extracts a subset of COCO
+
+The training dataset of the COCO2017 dataset includes 118k images, and the validation set includes 5k images, which is a relatively large dataset. Loading JSON in debugging or quick verification scenarios will consume more resources and bring slower startup speed.
+The `extract_subcoco.py` script provides the ability to extract a specified number of images. The user can use the `-num-img` parameter to get a COCO subset of the specified number of images.
+
+Currently, only support COCO2017. In the future will support user-defined datasets of standard coco JSON format.
+
+The root path folder format is as follows:
+
+```text
+├── root
+│   ├── annotations
+│   ├── train2017
+│   ├── val2017
+│   ├── test2017
+```
+
+1. Extract 10 training images and 10 validation images using only 5k validation sets.
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
+```
+
+2. Extract 20 training images using the training set and 20 validation images using the validation set.
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
+```

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -186,8 +186,8 @@ The converted `mmyolox.pt` can be used by MMYOLO.
 
 ## Extracts a subset of COCO
 
-The training dataset of the COCO2017 dataset includes 118k images, and the validation set includes 5k images, which is a relatively large dataset. Loading JSON in debugging or quick verification scenarios will consume more resources and bring slower startup speed.
-The `extract_subcoco.py` script provides the ability to extract a specified number of images. The user can use the `-num-img` parameter to get a COCO subset of the specified number of images.
+The training dataset of the COCO2017 dataset includes 118K images, and the validation set includes 5K images, which is a relatively large dataset. Loading JSON in debugging or quick verification scenarios will consume more resources and bring slower startup speed.
+The `extract_subcoco.py` script provides the ability to extract a specified number of images. The user can use the `--num-img` parameter to get a COCO subset of the specified number of images.
 
 Currently, only support COCO2017. In the future will support user-defined datasets of standard coco JSON format.
 
@@ -201,7 +201,7 @@ The root path folder format is as follows:
 │   ├── test2017
 ```
 
-1. Extract 10 training images and 10 validation images using only 5k validation sets.
+1. Extract 10 training images and 10 validation images using only 5K validation sets.
 
 ```shell
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
@@ -211,4 +211,10 @@ python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
 
 ```shell
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
+```
+
+3. Set the global seed to 1. Default is no setting
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set --seed 1
 ```

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -213,7 +213,7 @@ python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
 ```
 
-3. Set the global seed to 1. Default is no setting
+3. Set the global seed to 1. The default is no setting.
 
 ```shell
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set --seed 1

--- a/docs/zh_cn/user_guides/useful_tools.md
+++ b/docs/zh_cn/user_guides/useful_tools.md
@@ -181,3 +181,32 @@ python tools/model_converters/yolox_to_mmyolo.py --src yolox_s.pth --dst mmyolox
 ```
 
 转换好的 `mmyolox.pt` 即可以在 MMYOLO 中使用。
+
+## 提取 COCO 子集
+
+COCO2017 数据集训练数据集包括 118k 张图片，验证集包括 5k 张图片，数据集比较大。在调试或者快速验证程序是否正确的场景下加载 json 会需要消耗较多资源和带来较慢的启动速度，这会导致程序体验不好。
+`extract_subcoco.py` 脚本提供了切分指定张图片的功能，用户可以通过 `--num-img` 参数来得到指定图片数目的 COCO 子集，从而满足上述需求。
+
+注意： 本脚本目前仅仅支持 COCO2017 数据集，未来会支持更加通用的 COCO JSON 格式数据集
+
+输入 root 根路径文件夹格式如下所示：
+
+```text
+├── root
+│   ├── annotations
+│   ├── train2017
+│   ├── val2017
+│   ├── test2017
+```
+
+1. 仅仅使用 5k 张验证集切分出 10 张训练图片和 10 张验证图片
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
+```
+
+2. 使用训练集切分出 20 张训练图片，使用验证集切分出 20 张验证图片
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
+```

--- a/docs/zh_cn/user_guides/useful_tools.md
+++ b/docs/zh_cn/user_guides/useful_tools.md
@@ -184,7 +184,7 @@ python tools/model_converters/yolox_to_mmyolo.py --src yolox_s.pth --dst mmyolox
 
 ## 提取 COCO 子集
 
-COCO2017 数据集训练数据集包括 118k 张图片，验证集包括 5k 张图片，数据集比较大。在调试或者快速验证程序是否正确的场景下加载 json 会需要消耗较多资源和带来较慢的启动速度，这会导致程序体验不好。
+COCO2017 数据集训练数据集包括 118K 张图片，验证集包括 5K 张图片，数据集比较大。在调试或者快速验证程序是否正确的场景下加载 json 会需要消耗较多资源和带来较慢的启动速度，这会导致程序体验不好。
 `extract_subcoco.py` 脚本提供了切分指定张图片的功能，用户可以通过 `--num-img` 参数来得到指定图片数目的 COCO 子集，从而满足上述需求。
 
 注意： 本脚本目前仅仅支持 COCO2017 数据集，未来会支持更加通用的 COCO JSON 格式数据集
@@ -199,7 +199,7 @@ COCO2017 数据集训练数据集包括 118k 张图片，验证集包括 5k 张�
 │   ├── test2017
 ```
 
-1. 仅仅使用 5k 张验证集切分出 10 张训练图片和 10 张验证图片
+1. 仅仅使用 5K 张验证集切分出 10 张训练图片和 10 张验证图片
 
 ```shell
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
@@ -209,4 +209,10 @@ python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
 
 ```shell
 python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
+```
+
+3. 设置全局种子，默认不设置
+
+```shell
+python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set --seed 1
 ```

--- a/tools/misc/extract_subcoco.py
+++ b/tools/misc/extract_subcoco.py
@@ -1,0 +1,233 @@
+import argparse
+import os.path as osp
+import shutil
+from collections import defaultdict
+
+import mmengine
+import numpy as np
+from pycocotools.coco import COCO
+
+try:
+    import panopticapi
+except ImportError:
+    panopticapi = None
+
+
+class COCOPanoptic(COCO):
+    """This wrapper is for loading the panoptic style annotation file.
+
+    The format is shown in the CocoPanopticDataset class.
+
+    Args:
+        annotation_file (str, optional): Path of annotation file.
+            Defaults to None.
+    """
+
+    def __init__(self, annotation_file=None) -> None:
+        super().__init__(annotation_file)
+
+    def createIndex(self) -> None:
+        """Create index."""
+        # create index
+        print('creating index...')
+        # anns stores 'segment_id -> annotation'
+        anns, cats, imgs = {}, {}, {}
+        img_to_anns, cat_to_imgs = defaultdict(list), defaultdict(list)
+        if 'annotations' in self.dataset:
+            for ann in self.dataset['annotations']:
+                for seg_ann in ann['segments_info']:
+                    # to match with instance.json
+                    seg_ann['image_id'] = ann['image_id']
+                    img_to_anns[ann['image_id']].append(seg_ann)
+                    # segment_id is not unique in coco dataset orz...
+                    # annotations from different images but
+                    # may have same segment_id
+                    if seg_ann['id'] in anns.keys():
+                        anns[seg_ann['id']].append(seg_ann)
+                    else:
+                        anns[seg_ann['id']] = [seg_ann]
+
+            # filter out annotations from other images
+            img_to_anns_ = defaultdict(list)
+            for k, v in img_to_anns.items():
+                img_to_anns_[k] = [x for x in v if x['image_id'] == k]
+            img_to_anns = img_to_anns_
+
+        if 'images' in self.dataset:
+            for img_info in self.dataset['images']:
+                img_info['segm_file'] = img_info['file_name'].replace(
+                    'jpg', 'png')
+                imgs[img_info['id']] = img_info
+
+        if 'categories' in self.dataset:
+            for cat in self.dataset['categories']:
+                cats[cat['id']] = cat
+
+        if 'annotations' in self.dataset and 'categories' in self.dataset:
+            for ann in self.dataset['annotations']:
+                for seg_ann in ann['segments_info']:
+                    cat_to_imgs[seg_ann['category_id']].append(ann['image_id'])
+
+        print('index created!')
+
+        self.anns = anns
+        self.imgToAnns = img_to_anns
+        self.catToImgs = cat_to_imgs
+        self.imgs = imgs
+        self.cats = cats
+
+
+def _process_data(args, in_dataset_type: str, out_dataset_type: str):
+    assert in_dataset_type in ('train', 'val')
+    assert out_dataset_type in ('train', 'val')
+
+    year = '2017'
+    with_panoptic = args.panoptic
+
+    int_ann_file_name = f'annotations/instances_{in_dataset_type}{year}.json'
+    out_ann_file_name = f'annotations/instances_{out_dataset_type}{year}.json'
+
+    ann_path = osp.join(args.root, int_ann_file_name)
+    json_data = mmengine.load(ann_path)
+
+    new_json_data = {
+        'info': json_data['info'],
+        'licenses': json_data['licenses'],
+        'categories': json_data['categories'],
+        'images': [],
+        'annotations': []
+    }
+
+    images = json_data['images']
+    coco = COCO(ann_path)
+
+    if with_panoptic:
+        in_panoptic_ann_file_name = \
+            f'annotations/panoptic_{in_dataset_type}{year}.json'
+        out_panoptic_ann_file_name = \
+            f'annotations/panoptic_{out_dataset_type}{year}.json'
+
+        ann_path = osp.join(args.root, in_panoptic_ann_file_name)
+        json_data = mmengine.load(ann_path)
+        panoptic_new_json_data = {
+            'info': json_data['info'],
+            'licenses': json_data['licenses'],
+            'categories': json_data['categories'],
+            'images': [],
+            'annotations': []
+        }
+
+        panoptic_ann_path = osp.join(args.root, in_panoptic_ann_file_name)
+        coco_panoptic = COCOPanoptic(panoptic_ann_path)
+
+    # shuffle
+    np.random.shuffle(images)
+
+    progress_bar = mmengine.ProgressBar(args.num_img)
+
+    for i in range(args.num_img):
+        file_name = images[i]['file_name']
+        stuff_file_name = osp.splitext(file_name)[0] + '.png'
+        image_path = osp.join(args.root, in_dataset_type + year, file_name)
+        stuff_image_path = osp.join(args.root, 'stuffthingmaps',
+                                    in_dataset_type + year, stuff_file_name)
+
+        ann_ids = coco.getAnnIds(imgIds=[images[i]['id']])
+        ann_info = coco.loadAnns(ann_ids)
+
+        new_json_data['images'].append(images[i])
+        new_json_data['annotations'].extend(ann_info)
+
+        if with_panoptic:
+            panoptic_stuff_image_path = osp.join(
+                args.root, 'annotations', 'panoptic_' + in_dataset_type + year,
+                stuff_file_name)
+            panoptic_ann_info = coco_panoptic.imgToAnns.get(images[i]['id'])
+            ann_dict = {
+                'segments_info': panoptic_ann_info,
+                'file_name': stuff_file_name,
+                'image_id': images[i]['id']
+            }
+            panoptic_new_json_data['images'].append(images[i])
+            panoptic_new_json_data['annotations'].append(ann_dict)
+
+            if osp.exists(panoptic_stuff_image_path):
+                shutil.copy(
+                    panoptic_stuff_image_path,
+                    osp.join(args.out_dir, 'annotations',
+                             'panoptic_' + out_dataset_type + year,
+                             stuff_file_name))
+
+        shutil.copy(image_path, osp.join(args.out_dir,
+                                         out_dataset_type + year))
+        if osp.exists(stuff_image_path):
+            shutil.copy(
+                stuff_image_path,
+                osp.join(args.out_dir, 'stuffthingmaps',
+                         out_dataset_type + year))
+
+        progress_bar.update()
+
+    mmengine.dump(new_json_data, osp.join(args.out_dir, out_ann_file_name))
+
+    if with_panoptic:
+        mmengine.dump(panoptic_new_json_data,
+                      osp.join(args.out_dir, out_panoptic_ann_file_name))
+
+
+def _make_dirs(out_dir, with_panoptic: bool = False):
+    mmengine.mkdir_or_exist(out_dir)
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'annotations'))
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'train2017'))
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'val2017'))
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/train2017'))
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/val2017'))
+    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/val2017'))
+
+    if with_panoptic:
+        mmengine.mkdir_or_exist(
+            osp.join(out_dir, 'annotations/panoptic_train2017'))
+        mmengine.mkdir_or_exist(
+            osp.join(out_dir, 'annotations/panoptic_val2017'))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Extract coco subset')
+    parser.add_argument('root', help='root path')
+    parser.add_argument(
+        'out_dir', type=str, help='directory where subset coco will be saved.')
+    parser.add_argument(
+        '--num-img', default=50, type=int, help='num of extract image')
+    parser.add_argument(
+        '--use-training-set',
+        action='store_true',
+        help='Whether to use the training set when extract the training set. '
+        'The training subset is extracted from the validation set by '
+        'default which can speed up.')
+    parser.add_argument(
+        '--panoptic',
+        action='store_true',
+        help='Support to process panoptic dataset')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    assert args.out_dir != args.root, \
+        'The file will be overwritten in place, ' \
+        'so the same folder is not allowed !'
+
+    _make_dirs(args.out_dir, args.panoptic)
+
+    print('start processing train dataset')
+    if args.use_training_set:
+        _process_data(args, 'train', 'train')
+    else:
+        _process_data(args, 'val', 'train')
+    print('start processing val dataset')
+    _process_data(args, 'val', 'val')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/misc/extract_subcoco.py
+++ b/tools/misc/extract_subcoco.py
@@ -1,88 +1,38 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Extracting subsets from coco2017 dataset.
+
+This script is mainly used to debug and verify the correctness of the
+program quickly.
+The root folder format must be in the following format:
+
+├── root
+│   ├── annotations
+│   ├── train2017
+│   ├── val2017
+│   ├── test2017
+
+Currently, only support COCO2017. In the future will support user-defined
+datasets of standard coco JSON format.
+
+Example:
+   python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img ${NUM_IMG}
+"""
+
 import argparse
 import os.path as osp
 import shutil
-from collections import defaultdict
 
 import mmengine
 import numpy as np
 from pycocotools.coco import COCO
 
-try:
-    import panopticapi
-except ImportError:
-    panopticapi = None
 
-
-class COCOPanoptic(COCO):
-    """This wrapper is for loading the panoptic style annotation file.
-
-    The format is shown in the CocoPanopticDataset class.
-
-    Args:
-        annotation_file (str, optional): Path of annotation file.
-            Defaults to None.
-    """
-
-    def __init__(self, annotation_file=None) -> None:
-        super().__init__(annotation_file)
-
-    def createIndex(self) -> None:
-        """Create index."""
-        # create index
-        print('creating index...')
-        # anns stores 'segment_id -> annotation'
-        anns, cats, imgs = {}, {}, {}
-        img_to_anns, cat_to_imgs = defaultdict(list), defaultdict(list)
-        if 'annotations' in self.dataset:
-            for ann in self.dataset['annotations']:
-                for seg_ann in ann['segments_info']:
-                    # to match with instance.json
-                    seg_ann['image_id'] = ann['image_id']
-                    img_to_anns[ann['image_id']].append(seg_ann)
-                    # segment_id is not unique in coco dataset orz...
-                    # annotations from different images but
-                    # may have same segment_id
-                    if seg_ann['id'] in anns.keys():
-                        anns[seg_ann['id']].append(seg_ann)
-                    else:
-                        anns[seg_ann['id']] = [seg_ann]
-
-            # filter out annotations from other images
-            img_to_anns_ = defaultdict(list)
-            for k, v in img_to_anns.items():
-                img_to_anns_[k] = [x for x in v if x['image_id'] == k]
-            img_to_anns = img_to_anns_
-
-        if 'images' in self.dataset:
-            for img_info in self.dataset['images']:
-                img_info['segm_file'] = img_info['file_name'].replace(
-                    'jpg', 'png')
-                imgs[img_info['id']] = img_info
-
-        if 'categories' in self.dataset:
-            for cat in self.dataset['categories']:
-                cats[cat['id']] = cat
-
-        if 'annotations' in self.dataset and 'categories' in self.dataset:
-            for ann in self.dataset['annotations']:
-                for seg_ann in ann['segments_info']:
-                    cat_to_imgs[seg_ann['category_id']].append(ann['image_id'])
-
-        print('index created!')
-
-        self.anns = anns
-        self.imgToAnns = img_to_anns
-        self.catToImgs = cat_to_imgs
-        self.imgs = imgs
-        self.cats = cats
-
-
+# TODO: Currently only supports coco2017
 def _process_data(args, in_dataset_type: str, out_dataset_type: str):
     assert in_dataset_type in ('train', 'val')
     assert out_dataset_type in ('train', 'val')
 
     year = '2017'
-    with_panoptic = args.panoptic
 
     int_ann_file_name = f'annotations/instances_{in_dataset_type}{year}.json'
     out_ann_file_name = f'annotations/instances_{out_dataset_type}{year}.json'
@@ -101,25 +51,6 @@ def _process_data(args, in_dataset_type: str, out_dataset_type: str):
     images = json_data['images']
     coco = COCO(ann_path)
 
-    if with_panoptic:
-        in_panoptic_ann_file_name = \
-            f'annotations/panoptic_{in_dataset_type}{year}.json'
-        out_panoptic_ann_file_name = \
-            f'annotations/panoptic_{out_dataset_type}{year}.json'
-
-        ann_path = osp.join(args.root, in_panoptic_ann_file_name)
-        json_data = mmengine.load(ann_path)
-        panoptic_new_json_data = {
-            'info': json_data['info'],
-            'licenses': json_data['licenses'],
-            'categories': json_data['categories'],
-            'images': [],
-            'annotations': []
-        }
-
-        panoptic_ann_path = osp.join(args.root, in_panoptic_ann_file_name)
-        coco_panoptic = COCOPanoptic(panoptic_ann_path)
-
     # shuffle
     np.random.shuffle(images)
 
@@ -127,10 +58,7 @@ def _process_data(args, in_dataset_type: str, out_dataset_type: str):
 
     for i in range(args.num_img):
         file_name = images[i]['file_name']
-        stuff_file_name = osp.splitext(file_name)[0] + '.png'
         image_path = osp.join(args.root, in_dataset_type + year, file_name)
-        stuff_image_path = osp.join(args.root, 'stuffthingmaps',
-                                    in_dataset_type + year, stuff_file_name)
 
         ann_ids = coco.getAnnIds(imgIds=[images[i]['id']])
         ann_info = coco.loadAnns(ann_ids)
@@ -138,57 +66,19 @@ def _process_data(args, in_dataset_type: str, out_dataset_type: str):
         new_json_data['images'].append(images[i])
         new_json_data['annotations'].extend(ann_info)
 
-        if with_panoptic:
-            panoptic_stuff_image_path = osp.join(
-                args.root, 'annotations', 'panoptic_' + in_dataset_type + year,
-                stuff_file_name)
-            panoptic_ann_info = coco_panoptic.imgToAnns.get(images[i]['id'])
-            ann_dict = {
-                'segments_info': panoptic_ann_info,
-                'file_name': stuff_file_name,
-                'image_id': images[i]['id']
-            }
-            panoptic_new_json_data['images'].append(images[i])
-            panoptic_new_json_data['annotations'].append(ann_dict)
-
-            if osp.exists(panoptic_stuff_image_path):
-                shutil.copy(
-                    panoptic_stuff_image_path,
-                    osp.join(args.out_dir, 'annotations',
-                             'panoptic_' + out_dataset_type + year,
-                             stuff_file_name))
-
         shutil.copy(image_path, osp.join(args.out_dir,
                                          out_dataset_type + year))
-        if osp.exists(stuff_image_path):
-            shutil.copy(
-                stuff_image_path,
-                osp.join(args.out_dir, 'stuffthingmaps',
-                         out_dataset_type + year))
 
         progress_bar.update()
 
     mmengine.dump(new_json_data, osp.join(args.out_dir, out_ann_file_name))
 
-    if with_panoptic:
-        mmengine.dump(panoptic_new_json_data,
-                      osp.join(args.out_dir, out_panoptic_ann_file_name))
 
-
-def _make_dirs(out_dir, with_panoptic: bool = False):
+def _make_dirs(out_dir):
     mmengine.mkdir_or_exist(out_dir)
     mmengine.mkdir_or_exist(osp.join(out_dir, 'annotations'))
     mmengine.mkdir_or_exist(osp.join(out_dir, 'train2017'))
     mmengine.mkdir_or_exist(osp.join(out_dir, 'val2017'))
-    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/train2017'))
-    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/val2017'))
-    mmengine.mkdir_or_exist(osp.join(out_dir, 'stuffthingmaps/val2017'))
-
-    if with_panoptic:
-        mmengine.mkdir_or_exist(
-            osp.join(out_dir, 'annotations/panoptic_train2017'))
-        mmengine.mkdir_or_exist(
-            osp.join(out_dir, 'annotations/panoptic_val2017'))
 
 
 def parse_args():
@@ -204,10 +94,6 @@ def parse_args():
         help='Whether to use the training set when extract the training set. '
         'The training subset is extracted from the validation set by '
         'default which can speed up.')
-    parser.add_argument(
-        '--panoptic',
-        action='store_true',
-        help='Support to process panoptic dataset')
     args = parser.parse_args()
     return args
 
@@ -218,7 +104,7 @@ def main():
         'The file will be overwritten in place, ' \
         'so the same folder is not allowed !'
 
-    _make_dirs(args.out_dir, args.panoptic)
+    _make_dirs(args.out_dir)
 
     print('start processing train dataset')
     if args.use_training_set:

--- a/tools/misc/extract_subcoco.py
+++ b/tools/misc/extract_subcoco.py
@@ -28,11 +28,12 @@ from pycocotools.coco import COCO
 
 
 # TODO: Currently only supports coco2017
-def _process_data(args, in_dataset_type: str, out_dataset_type: str):
+def _process_data(args,
+                  in_dataset_type: str,
+                  out_dataset_type: str,
+                  year: str = '2017'):
     assert in_dataset_type in ('train', 'val')
     assert out_dataset_type in ('train', 'val')
-
-    year = '2017'
 
     int_ann_file_name = f'annotations/instances_{in_dataset_type}{year}.json'
     out_ann_file_name = f'annotations/instances_{out_dataset_type}{year}.json'
@@ -94,6 +95,7 @@ def parse_args():
         help='Whether to use the training set when extract the training set. '
         'The training subset is extracted from the validation set by '
         'default which can speed up.')
+    parser.add_argument('--seed', default=-1, type=int, help='seed')
     args = parser.parse_args()
     return args
 
@@ -104,15 +106,21 @@ def main():
         'The file will be overwritten in place, ' \
         'so the same folder is not allowed !'
 
+    seed = int(args.seed)
+    if seed != -1:
+        print(f'Set the global seed: {seed}')
+        np.random.seed(int(args.seed))
+
     _make_dirs(args.out_dir)
 
-    print('start processing train dataset')
+    print('====Start processing train dataset====')
     if args.use_training_set:
         _process_data(args, 'train', 'train')
     else:
         _process_data(args, 'val', 'train')
-    print('start processing val dataset')
+    print('\n====Start processing val dataset====')
     _process_data(args, 'val', 'val')
+    print(f'\n Result save to {args.out_dir}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

## Motivation

The training dataset of the COCO2017 dataset includes 118k images, and the validation set includes 5k images, which is a relatively large dataset. Loading JSON in debugging or quick verification scenarios will consume more resources and bring slower startup speed.
The `extract_subcoco.py` script provides the ability to extract a specified number of images. The user can use the `-num-img` parameter to get a COCO subset of the specified number of images.


Currently, only support COCO2017. In the future will support user-defined datasets of standard coco JSON format.

The root path folder format is as follows:

```text
├── root
│   ├── annotations
│   ├── train2017
│   ├── val2017
│   ├── test2017
```

1. Extract 10 training images and 10 validation images using only 5k validation sets.

```shell
python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 10
```

2. Extract 20 training images using the training set and 20 validation images using the validation set.

```shell
python tools/misc/extract_subcoco.py ${ROOT} ${OUT_DIR} --num-img 20 --use-training-set
```
