### PR TITLE
[Fix] Fix mmyolo rtmdet deployment.

### DIFF
--- a/mmyolo/deploy/object_detection.py
+++ b/mmyolo/deploy/object_detection.py
@@ -17,12 +17,21 @@ class MMYOLO(MMCodebase):
     task_registry = MMYOLO_TASK
 
     @classmethod
+    def register_deploy_modules(cls):
+        """register all rewriters for mmcls."""
+        import mmdeploy.codebase.mmdet.models  # noqa: F401
+        import mmdeploy.codebase.mmdet.ops  # noqa: F401
+        import mmdeploy.codebase.mmdet.structures  # noqa: F401
+
+    @classmethod
     def register_all_modules(cls):
         from mmdet.utils.setup_env import \
             register_all_modules as register_all_modules_mmdet
 
         from mmyolo.utils.setup_env import \
             register_all_modules as register_all_modules_mmyolo
+
+        cls.register_deploy_modules()
         register_all_modules_mmyolo(True)
         register_all_modules_mmdet(False)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

rtmdet deploy in mmyolo has failed in mmdeploy's regression test

## Modification

Add mmdet rewriter for mmyolo because some models in mmyolo multiplex the mmdet rewriters.

## BC-breaking (Optional)

None.

## Use cases (Optional)

Uses in mmdeploy
```bash
python tools/deploy.py ../mmyolo/configs/deploy/detection_tensorrt_dynamic-192x192-960x960.py ../mmyolo/configs/yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py https://download.openmmlab.com/mmyolo/v0/yolov5/yolov5_s-v61_syncbn_fast_8xb16-300e_coco/yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth ../mmyolo/demo/demo.jpg --work-dir ./yolov5 --device cuda:0
```

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
