### PR TITLE
[Fix] Fix scale factor type of `LetterResize` and `YOLOv5KeepRatioResize`

### DIFF
--- a/mmyolo/datasets/transforms/transforms.py
+++ b/mmyolo/datasets/transforms/transforms.py
@@ -104,8 +104,7 @@ class YOLOv5KeepRatioResize(MMDET_Resize):
             resized_h, resized_w = image.shape[:2]
             scale_ratio = resized_h / original_h
 
-            scale_factor = np.array([scale_ratio, scale_ratio],
-                                    dtype=np.float32)
+            scale_factor = (scale_ratio, scale_ratio)
 
             results['img'] = image
             results['img_shape'] = image.shape[:2]
@@ -207,11 +206,12 @@ class LetterResize(MMDET_Resize):
                 image, (no_pad_shape[1], no_pad_shape[0]),
                 interpolation=self.interpolation,
                 backend=self.backend)
-#
-        scale_factor = np.array([ratio[0], ratio[1]], dtype=np.float32)
+
+        scale_factor = (ratio[0], ratio[1])
 
         if 'scale_factor' in results:
-            results['scale_factor'] = results['scale_factor'] * scale_factor
+            results['scale_factor'] = (results['scale_factor'][0] * scale_factor[0],
+                                       results['scale_factor'][1] * scale_factor[1])
         else:
             results['scale_factor'] = scale_factor
 

--- a/mmyolo/datasets/transforms/transforms.py
+++ b/mmyolo/datasets/transforms/transforms.py
@@ -207,7 +207,7 @@ class LetterResize(MMDET_Resize):
                 interpolation=self.interpolation,
                 backend=self.backend)
 
-        scale_factor = (ratio[0], ratio[1])
+        scale_factor = (ratio[1], ratio[0])  # mmcv scale factor is (w, h)
 
         if 'scale_factor' in results:
             results['scale_factor'] = (results['scale_factor'][0] *

--- a/mmyolo/datasets/transforms/transforms.py
+++ b/mmyolo/datasets/transforms/transforms.py
@@ -210,8 +210,10 @@ class LetterResize(MMDET_Resize):
         scale_factor = (ratio[0], ratio[1])
 
         if 'scale_factor' in results:
-            results['scale_factor'] = (results['scale_factor'][0] * scale_factor[0],
-                                       results['scale_factor'][1] * scale_factor[1])
+            results['scale_factor'] = (results['scale_factor'][0] *
+                                       scale_factor[0],
+                                       results['scale_factor'][1] *
+                                       scale_factor[1])
         else:
             results['scale_factor'] = scale_factor
 

--- a/mmyolo/datasets/transforms/transforms.py
+++ b/mmyolo/datasets/transforms/transforms.py
@@ -207,7 +207,7 @@ class LetterResize(MMDET_Resize):
                 image, (no_pad_shape[1], no_pad_shape[0]),
                 interpolation=self.interpolation,
                 backend=self.backend)
-
+#
         scale_factor = np.array([ratio[0], ratio[1]], dtype=np.float32)
 
         if 'scale_factor' in results:

--- a/tests/test_datasets/test_transforms/test_transforms.py
+++ b/tests/test_datasets/test_transforms/test_transforms.py
@@ -48,7 +48,7 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue(
             (results['pad_param'] == np.array([80., 80., 136., 136.])).all())
-        self.assertTrue((results['scale_factor'] <= 1.).all())
+        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
 
         # Test pad_val
         transform = LetterResize(scale=(640, 640), pad_val=dict(img=144))
@@ -59,7 +59,7 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue((results['pad_param'] == np.array([0., 0., 29.,
                                                            30.])).all())
-        self.assertTrue((results['scale_factor'] > 1.).all())
+        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
 
         # Test use_mini_pad
         transform = LetterResize(scale=(640, 640), use_mini_pad=True)
@@ -70,7 +70,7 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue((results['pad_param'] == np.array([0., 0., 13.,
                                                            14.])).all())
-        self.assertTrue((results['scale_factor'] > 1.).all())
+        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
 
         # Test stretch_only
         transform = LetterResize(scale=(640, 640), stretch_only=True)
@@ -150,13 +150,13 @@ class TestYOLOv5KeepRatioResize(unittest.TestCase):
         self.assertEqual(results['img_shape'], (480, 640))
         self.assertTrue(
             (results['gt_bboxes'] == np.array([[0., 0., 240., 240.]])).all())
-        self.assertTrue((results['scale_factor'] == 1.6).all())
+        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) == 1.6).all())
 
         # Test only img
         transform = YOLOv5KeepRatioResize(scale=(640, 640))
         results = transform(copy.deepcopy(self.data_info2))
         self.assertEqual(results['img_shape'], (480, 640))
-        self.assertTrue((results['scale_factor'] == 1.6).all())
+        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) == 1.6).all())
 
 
 class TestYOLOv5HSVRandomAug(unittest.TestCase):

--- a/tests/test_datasets/test_transforms/test_transforms.py
+++ b/tests/test_datasets/test_transforms/test_transforms.py
@@ -48,7 +48,8 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue(
             (results['pad_param'] == np.array([80., 80., 136., 136.])).all())
-        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
+        self.assertTrue(
+            (np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
 
         # Test pad_val
         transform = LetterResize(scale=(640, 640), pad_val=dict(img=144))
@@ -59,7 +60,8 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue((results['pad_param'] == np.array([0., 0., 29.,
                                                            30.])).all())
-        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
+        self.assertTrue(
+            (np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
 
         # Test use_mini_pad
         transform = LetterResize(scale=(640, 640), use_mini_pad=True)
@@ -70,7 +72,8 @@ class TestLetterResize(unittest.TestCase):
         self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
         self.assertTrue((results['pad_param'] == np.array([0., 0., 13.,
                                                            14.])).all())
-        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
+        self.assertTrue(
+            (np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
 
         # Test stretch_only
         transform = LetterResize(scale=(640, 640), stretch_only=True)
@@ -150,13 +153,15 @@ class TestYOLOv5KeepRatioResize(unittest.TestCase):
         self.assertEqual(results['img_shape'], (480, 640))
         self.assertTrue(
             (results['gt_bboxes'] == np.array([[0., 0., 240., 240.]])).all())
-        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) == 1.6).all())
+        self.assertTrue((np.array(results['scale_factor'],
+                                  dtype=np.float32) == 1.6).all())
 
         # Test only img
         transform = YOLOv5KeepRatioResize(scale=(640, 640))
         results = transform(copy.deepcopy(self.data_info2))
         self.assertEqual(results['img_shape'], (480, 640))
-        self.assertTrue((np.array(results['scale_factor'], dtype=np.float32) == 1.6).all())
+        self.assertTrue((np.array(results['scale_factor'],
+                                  dtype=np.float32) == 1.6).all())
 
 
 class TestYOLOv5HSVRandomAug(unittest.TestCase):

--- a/tests/test_datasets/test_transforms/test_transforms.py
+++ b/tests/test_datasets/test_transforms/test_transforms.py
@@ -27,62 +27,62 @@ class TestLetterResize(unittest.TestCase):
         self.data_info1 = dict(
             img=np.random.random((300, 400, 3)),
             gt_bboxes=np.array([[0, 0, 150, 150]], dtype=np.float32),
-            batch_shape=np.array([460, 672], dtype=np.int64),
+            batch_shape=np.array([192, 672], dtype=np.int64),
             gt_masks=BitmapMasks(rng.rand(1, 300, 400), height=300, width=400))
         self.data_info2 = dict(
             img=np.random.random((300, 400, 3)),
             gt_bboxes=np.array([[0, 0, 150, 150]], dtype=np.float32))
         self.data_info3 = dict(
             img=np.random.random((300, 400, 3)),
-            batch_shape=np.array([460, 672], dtype=np.int64))
+            batch_shape=np.array([192, 672], dtype=np.int64))
         self.data_info4 = dict(img=np.random.random((300, 400, 3)))
 
     def test_letter_resize(self):
         # Test allow_scale_up
         transform = LetterResize(scale=(640, 640), allow_scale_up=False)
         results = transform(copy.deepcopy(self.data_info1))
-        self.assertEqual(results['img_shape'], (460, 672, 3))
+        self.assertEqual(results['img_shape'], (192, 672, 3))
         self.assertTrue(
-            (results['gt_bboxes'] == np.array([[136., 80., 286.,
-                                                230.]])).all())
-        self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
-        self.assertTrue(
-            (results['pad_param'] == np.array([80., 80., 136., 136.])).all())
+            (results['gt_bboxes'] == np.array([[208., 0., 304., 96.]])).all())
+        self.assertTrue((results['batch_shape'] == np.array([192, 672])).all())
+        self.assertTrue((results['pad_param'] == np.array([0., 0., 208.,
+                                                           208.])).all())
         self.assertTrue(
             (np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
 
         # Test pad_val
         transform = LetterResize(scale=(640, 640), pad_val=dict(img=144))
         results = transform(copy.deepcopy(self.data_info1))
-        self.assertEqual(results['img_shape'], (460, 672, 3))
+        self.assertEqual(results['img_shape'], (192, 672, 3))
         self.assertTrue(
-            (results['gt_bboxes'] == np.array([[29., 0., 259., 230.]])).all())
-        self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
-        self.assertTrue((results['pad_param'] == np.array([0., 0., 29.,
-                                                           30.])).all())
+            (results['gt_bboxes'] == np.array([[208., 0., 304., 96.]])).all())
+        self.assertTrue((results['batch_shape'] == np.array([192, 672])).all())
+        self.assertTrue((results['pad_param'] == np.array([0., 0., 208.,
+                                                           208.])).all())
         self.assertTrue(
-            (np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
+            (np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
 
         # Test use_mini_pad
         transform = LetterResize(scale=(640, 640), use_mini_pad=True)
         results = transform(copy.deepcopy(self.data_info1))
-        self.assertEqual(results['img_shape'], (460, 640, 3))
+        self.assertEqual(results['img_shape'], (192, 256, 3))
+        self.assertTrue((results['gt_bboxes'] == np.array([[0., 0., 96.,
+                                                            96.]])).all())
+        self.assertTrue((results['batch_shape'] == np.array([192, 672])).all())
+        self.assertTrue((results['pad_param'] == np.array([0., 0., 0.,
+                                                           0.])).all())
         self.assertTrue(
-            (results['gt_bboxes'] == np.array([[13., 0., 243., 230.]])).all())
-        self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
-        self.assertTrue((results['pad_param'] == np.array([0., 0., 13.,
-                                                           14.])).all())
-        self.assertTrue(
-            (np.array(results['scale_factor'], dtype=np.float32) > 1.).all())
+            (np.array(results['scale_factor'], dtype=np.float32) <= 1.).all())
 
         # Test stretch_only
         transform = LetterResize(scale=(640, 640), stretch_only=True)
         results = transform(copy.deepcopy(self.data_info1))
-        self.assertEqual(results['img_shape'], (460, 672, 3))
+        self.assertEqual(results['img_shape'], (192, 672, 3))
         self.assertTrue((results['gt_bboxes'] == np.array(
-            [[0., 0., 230., 251.99998474121094]])).all())
-        self.assertTrue((results['batch_shape'] == np.array([460, 672])).all())
-        self.assertTrue((results['pad_param'] == np.array([0, 0, 0, 0])).all())
+            [[0., 0., 251.99998474121094, 96.]])).all())
+        self.assertTrue((results['batch_shape'] == np.array([192, 672])).all())
+        self.assertTrue((results['pad_param'] == np.array([0., 0., 0.,
+                                                           0.])).all())
 
         # Test
         transform = LetterResize(scale=(640, 640), pad_val=dict(img=144))


### PR DESCRIPTION
## Motivation

Will crash when 
```python
            input_h, input_w = 222, 117
            output_h, output_w = (407, 684)
```

![image](https://user-images.githubusercontent.com/25873202/202944452-78f4097a-1019-4e14-bcc0-4fc47b3997a9.png)

## Modification

Fix scale factor type of LetterResize and YOLOv5KeepRatioResize, from `np` -> `tupe`

## test script
```bash
python tools/test.py \
    configs/yolov5/yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py 
    work_dirs/yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth 
```

## Before metric

```bash
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.377
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.571
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.410
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.217
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.425
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.488
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.310
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.516
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.572
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.384
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.629
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.720
```

```bash
bbox_mAP_copypaste: 0.377 0.571 0.410 0.217 0.425 0.488
coco/bbox_mAP: 0.3770  coco/bbox_mAP_50: 0.5710  coco/bbox_mAP_75: 0.4100  coco/bbox_mAP_s: 0.2170  coco/bbox_mAP_m: 0.4250  coco/bbox_mAP_l: 0.4880
```


## After metric

```bash
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.377
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=100 ] = 0.571
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=100 ] = 0.410
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.217
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.425
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.488
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=  1 ] = 0.310
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets= 10 ] = 0.516
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.572
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=100 ] = 0.384
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=100 ] = 0.629
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=100 ] = 0.720
```

```bash
bbox_mAP_copypaste: 0.377 0.571 0.410 0.217 0.425 0.488
coco/bbox_mAP: 0.3770  coco/bbox_mAP_50: 0.5710  coco/bbox_mAP_75: 0.4100  coco/bbox_mAP_s: 0.2170  coco/bbox_mAP_m: 0.4250  coco/bbox_mAP_l: 0.4880
```

## Compare before and after
```bash
Before: coco/bbox_mAP: 0.3770  coco/bbox_mAP_50: 0.5710  coco/bbox_mAP_75: 0.4100  coco/bbox_mAP_s: 0.2170  coco/bbox_mAP_m: 0.4250  coco/bbox_mAP_l: 0.4880
After:  coco/bbox_mAP: 0.3770  coco/bbox_mAP_50: 0.5710  coco/bbox_mAP_75: 0.4100  coco/bbox_mAP_s: 0.2170  coco/bbox_mAP_m: 0.4250  coco/bbox_mAP_l: 0.4880
```

## UT
![image](https://user-images.githubusercontent.com/25873202/202949143-053b1cc0-8e13-4ea4-9cfb-e05c9625a473.png)

![image](https://user-images.githubusercontent.com/25873202/202974283-958d7741-410f-4b55-a9fd-4b4d3193e156.png)



