### PR TITLE
[Improvement] Add `--class-name` for filter when save to labelme label.

### DIFF
--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -32,6 +32,11 @@ def parse_args():
     parser.add_argument(
         '--score-thr', type=float, default=0.3, help='Bbox score threshold')
     parser.add_argument(
+        '--class-name',
+        nargs='+',
+        type=str,
+        help='Only Save those classes if set')
+    parser.add_argument(
         '--to-labelme',
         action='store_true',
         help='Output labelme style label file')
@@ -92,7 +97,7 @@ def main():
             # save result to labelme files
             out_file = out_file.replace(
                 os.path.splitext(out_file)[-1], '.json')
-            to_label_format(result, out_file, pred_instances)
+            to_label_format(result, out_file, pred_instances, args.class_name)
             continue
 
         visualizer.add_datasample(

--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -10,8 +10,7 @@ from mmengine.utils import ProgressBar
 from mmyolo.registry import VISUALIZERS
 from mmyolo.utils import register_all_modules, switch_to_deploy
 from mmyolo.utils.labelme_utils import LabelmeFormat
-from mmyolo.utils.misc import get_file_list
-from tools.analysis_tools.dataset_analysis import show_data_classes
+from mmyolo.utils.misc import get_file_list, show_data_classes
 
 
 def parse_args():

--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -11,6 +11,7 @@ from mmyolo.registry import VISUALIZERS
 from mmyolo.utils import register_all_modules, switch_to_deploy
 from mmyolo.utils.labelme_utils import LabelmeFormat
 from mmyolo.utils.misc import get_file_list
+from tools.analysis_tools.dataset_analysis import show_data_classes
 
 
 def parse_args():
@@ -70,8 +71,21 @@ def main():
     # get file list
     files, source_type = get_file_list(args.img)
 
+    # get model class name
+    dataset_classes = model.dataset_meta.get('CLASSES')
+
     # ready for labelme format if it is needed
-    to_label_format = LabelmeFormat(classes=model.dataset_meta.get('CLASSES'))
+    to_label_format = LabelmeFormat(classes=dataset_classes)
+
+    # check class name
+    if args.class_name is not None:
+        for class_name in args.class_name:
+            if class_name in dataset_classes:
+                continue
+            show_data_classes(dataset_classes)
+            raise RuntimeError(
+                'Expected args.class_name to be one of the list, '
+                f'but got "{class_name}"')
 
     # start detector inference
     progress_bar = ProgressBar(len(files))

--- a/demo/image_demo.py
+++ b/demo/image_demo.py
@@ -97,7 +97,8 @@ def main():
             # save result to labelme files
             out_file = out_file.replace(
                 os.path.splitext(out_file)[-1], '.json')
-            to_label_format(result, out_file, pred_instances, args.class_name)
+            to_label_format(pred_instances, result.metainfo, out_file,
+                            args.class_name)
             continue
 
         visualizer.add_datasample(

--- a/mmyolo/utils/labelme_utils.py
+++ b/mmyolo/utils/labelme_utils.py
@@ -1,7 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import json
 
-from mmdet.structures import DetDataSample
 from mmengine.structures import InstanceData
 
 
@@ -12,22 +11,21 @@ class LabelmeFormat:
 
     Args:
         classes (tuple): Model classes name.
-        score_threshold (float): Predict score threshold.
     """
 
     def __init__(self, classes: tuple):
         super().__init__()
         self.classes = classes
 
-    def __call__(self, results: DetDataSample, output_path: str,
-                 pred_instances: InstanceData, class_name: list):
+    def __call__(self, pred_instances: InstanceData, metainfo: dict,
+                 output_path: str, selected_classes: list):
         """Get image data field for labelme.
 
         Args:
-            results (DetDataSample): Predict info.
-            output_path (str): Image file path.
             pred_instances (InstanceData): Candidate prediction info.
-            class_name (list): Filter class name.
+            metainfo (dict): Meta info of prediction.
+            output_path (str): Image file path.
+            selected_classes (list): Selected class name.
 
         Labelme file eg.
             {
@@ -59,24 +57,24 @@ class LabelmeFormat:
             }
         """
 
-        image_path = results.metainfo['img_path']
+        image_path = metainfo['img_path']
 
         json_info = {
             'version': '5.0.5',
             'flags': {},
             'imagePath': image_path,
             'imageData': None,
-            'imageHeight': results.ori_shape[0],
-            'imageWidth': results.ori_shape[1],
+            'imageHeight': metainfo['ori_shape'][0],
+            'imageWidth': metainfo['ori_shape'][1],
             'shapes': []
         }
 
-        for pred_info in pred_instances:
-            pred_bbox = pred_info.bboxes.cpu().numpy().tolist()[0]
-            pred_label = self.classes[pred_info.labels]
+        for pred_instance in pred_instances:
+            pred_bbox = pred_instance.bboxes.cpu().numpy().tolist()[0]
+            pred_label = self.classes[pred_instance.labels]
 
-            if class_name is not None and \
-                    pred_label not in class_name:
+            if selected_classes is not None and \
+                    pred_label not in selected_classes:
                 # filter class name
                 continue
 

--- a/mmyolo/utils/labelme_utils.py
+++ b/mmyolo/utils/labelme_utils.py
@@ -20,13 +20,14 @@ class LabelmeFormat:
         self.classes = classes
 
     def __call__(self, results: DetDataSample, output_path: str,
-                 pred_instances: InstanceData):
+                 pred_instances: InstanceData, class_name: list):
         """Get image data field for labelme.
 
         Args:
             results (DetDataSample): Predict info.
             output_path (str): Image file path.
             pred_instances (InstanceData): Candidate prediction info.
+            class_name (list): Filter class name.
 
         Labelme file eg.
             {
@@ -73,6 +74,11 @@ class LabelmeFormat:
         for pred_info in pred_instances:
             pred_bbox = pred_info.bboxes.cpu().numpy().tolist()[0]
             pred_label = self.classes[pred_info.labels]
+
+            if class_name is not None and \
+                    pred_label not in class_name:
+                # filter class name
+                continue
 
             sub_dict = {
                 'label': pred_label,

--- a/mmyolo/utils/misc.py
+++ b/mmyolo/utils/misc.py
@@ -5,6 +5,7 @@ import urllib
 import numpy as np
 import torch
 from mmengine.utils import scandir
+from prettytable import PrettyTable
 
 from mmyolo.models import RepVGGBlock
 
@@ -90,3 +91,76 @@ def get_file_list(source_root: str) -> [list, dict]:
     source_type = dict(is_dir=is_dir, is_url=is_url, is_file=is_file)
 
     return source_file_path_list, source_type
+
+
+def show_class_list(classes, class_num):
+    """Print the data of the class obtained by the current run."""
+    print('\n\nThe information obtained is as follows:')
+    class_info = PrettyTable()
+    class_info.title = 'Information of dataset class'
+    # List Print Settings
+    # If the quantity is too large, 25 rows will be displayed in each column
+    if len(classes) < 25:
+        class_info.add_column('Class name', classes)
+        class_info.add_column('Bbox num', class_num)
+    elif len(classes) % 25 != 0 and len(classes) > 25:
+        col_num = int(len(classes) / 25) + 1
+        class_nums = class_num.tolist()
+        class_name_list = list(classes)
+        for i in range(0, (col_num * 25) - len(classes)):
+            class_name_list.append('')
+            class_nums.append('')
+        for i in range(0, len(class_name_list), 25):
+            class_info.add_column('Class name', class_name_list[i:i + 25])
+            class_info.add_column('Bbox num', class_nums[i:i + 25])
+
+    # Align display data to the left
+    class_info.align['Class name'] = 'l'
+    class_info.align['Bbox num'] = 'l'
+    print(class_info)
+
+
+def show_data_list(args, area_rule):
+    """Print run setup information."""
+    print('\n\nPrint current running information:')
+    data_info = PrettyTable()
+    data_info.title = 'Dataset information'
+    # Print the corresponding information according to the settings
+    if args.val_dataset is False:
+        data_info.add_column('Dataset type', ['train_dataset'])
+    elif args.val_dataset is True:
+        data_info.add_column('Dataset type', ['val_dataset'])
+    if args.class_name is None:
+        data_info.add_column('Class name', ['All classes'])
+    else:
+        data_info.add_column('Class name', [args.class_name])
+    if args.func is None:
+        data_info.add_column('Function', ['All function'])
+    else:
+        data_info.add_column('Function', [args.func])
+    data_info.add_column('Area rule', [area_rule])
+
+    print(data_info)
+
+
+def show_data_classes(data_classes):
+    """When printing an error, all class names of the dataset."""
+    print('\n\nThe name of the class contained in the dataset:')
+    data_classes_info = PrettyTable()
+    data_classes_info.title = 'Information of dataset class'
+    # List Print Settings
+    # If the quantity is too large, 25 rows will be displayed in each column
+    if len(data_classes) < 25:
+        data_classes_info.add_column('Class name', data_classes)
+    elif len(data_classes) % 25 != 0 and len(data_classes) > 25:
+        col_num = int(len(data_classes) / 25) + 1
+        data_name_list = list(data_classes)
+        for i in range(0, (col_num * 25) - len(data_classes)):
+            data_name_list.append('')
+        for i in range(0, len(data_name_list), 25):
+            data_classes_info.add_column('Class name',
+                                         data_name_list[i:i + 25])
+
+    # Align display data to the left
+    data_classes_info.align['Class name'] = 'l'
+    print(data_classes_info)

--- a/mmyolo/utils/misc.py
+++ b/mmyolo/utils/misc.py
@@ -93,56 +93,6 @@ def get_file_list(source_root: str) -> [list, dict]:
     return source_file_path_list, source_type
 
 
-def show_class_list(classes, class_num):
-    """Print the data of the class obtained by the current run."""
-    print('\n\nThe information obtained is as follows:')
-    class_info = PrettyTable()
-    class_info.title = 'Information of dataset class'
-    # List Print Settings
-    # If the quantity is too large, 25 rows will be displayed in each column
-    if len(classes) < 25:
-        class_info.add_column('Class name', classes)
-        class_info.add_column('Bbox num', class_num)
-    elif len(classes) % 25 != 0 and len(classes) > 25:
-        col_num = int(len(classes) / 25) + 1
-        class_nums = class_num.tolist()
-        class_name_list = list(classes)
-        for i in range(0, (col_num * 25) - len(classes)):
-            class_name_list.append('')
-            class_nums.append('')
-        for i in range(0, len(class_name_list), 25):
-            class_info.add_column('Class name', class_name_list[i:i + 25])
-            class_info.add_column('Bbox num', class_nums[i:i + 25])
-
-    # Align display data to the left
-    class_info.align['Class name'] = 'l'
-    class_info.align['Bbox num'] = 'l'
-    print(class_info)
-
-
-def show_data_list(args, area_rule):
-    """Print run setup information."""
-    print('\n\nPrint current running information:')
-    data_info = PrettyTable()
-    data_info.title = 'Dataset information'
-    # Print the corresponding information according to the settings
-    if args.val_dataset is False:
-        data_info.add_column('Dataset type', ['train_dataset'])
-    elif args.val_dataset is True:
-        data_info.add_column('Dataset type', ['val_dataset'])
-    if args.class_name is None:
-        data_info.add_column('Class name', ['All classes'])
-    else:
-        data_info.add_column('Class name', [args.class_name])
-    if args.func is None:
-        data_info.add_column('Function', ['All function'])
-    else:
-        data_info.add_column('Function', [args.func])
-    data_info.add_column('Area rule', [area_rule])
-
-    print(data_info)
-
-
 def show_data_classes(data_classes):
     """When printing an error, all class names of the dataset."""
     print('\n\nThe name of the class contained in the dataset:')

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,1 +1,2 @@
 numpy
+prettytable

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,6 +6,7 @@ isort==4.3.21
 kwarray
 memory_profiler
 parameterized
+prettytable
 protobuf<=3.20.1
 psutil
 pytest

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,7 +6,6 @@ isort==4.3.21
 kwarray
 memory_profiler
 parameterized
-prettytable
 protobuf<=3.20.1
 psutil
 pytest

--- a/tools/analysis_tools/dataset_analysis.py
+++ b/tools/analysis_tools/dataset_analysis.py
@@ -8,11 +8,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from mmengine.config import Config
 from mmengine.utils import ProgressBar
+from prettytable import PrettyTable
 
 from mmyolo.registry import DATASETS
 from mmyolo.utils import register_all_modules
-from mmyolo.utils.misc import (show_class_list, show_data_classes,
-                               show_data_list)
+from mmyolo.utils.misc import show_data_classes
 
 
 def parse_args():
@@ -296,6 +296,56 @@ def show_bbox_area(args, fig_set, area_rule, class_name, bbox_area_num):
         pad_inches=0.1)  # Save Image
     plt.close()
     print(f'End and save in {out_dir}/{out_name}_bbox_area.jpg')
+
+
+def show_class_list(classes, class_num):
+    """Print the data of the class obtained by the current run."""
+    print('\n\nThe information obtained is as follows:')
+    class_info = PrettyTable()
+    class_info.title = 'Information of dataset class'
+    # List Print Settings
+    # If the quantity is too large, 25 rows will be displayed in each column
+    if len(classes) < 25:
+        class_info.add_column('Class name', classes)
+        class_info.add_column('Bbox num', class_num)
+    elif len(classes) % 25 != 0 and len(classes) > 25:
+        col_num = int(len(classes) / 25) + 1
+        class_nums = class_num.tolist()
+        class_name_list = list(classes)
+        for i in range(0, (col_num * 25) - len(classes)):
+            class_name_list.append('')
+            class_nums.append('')
+        for i in range(0, len(class_name_list), 25):
+            class_info.add_column('Class name', class_name_list[i:i + 25])
+            class_info.add_column('Bbox num', class_nums[i:i + 25])
+
+    # Align display data to the left
+    class_info.align['Class name'] = 'l'
+    class_info.align['Bbox num'] = 'l'
+    print(class_info)
+
+
+def show_data_list(args, area_rule):
+    """Print run setup information."""
+    print('\n\nPrint current running information:')
+    data_info = PrettyTable()
+    data_info.title = 'Dataset information'
+    # Print the corresponding information according to the settings
+    if args.val_dataset is False:
+        data_info.add_column('Dataset type', ['train_dataset'])
+    elif args.val_dataset is True:
+        data_info.add_column('Dataset type', ['val_dataset'])
+    if args.class_name is None:
+        data_info.add_column('Class name', ['All classes'])
+    else:
+        data_info.add_column('Class name', [args.class_name])
+    if args.func is None:
+        data_info.add_column('Function', ['All function'])
+    else:
+        data_info.add_column('Function', [args.func])
+    data_info.add_column('Area rule', [area_rule])
+
+    print(data_info)
 
 
 def main():

--- a/tools/analysis_tools/dataset_analysis.py
+++ b/tools/analysis_tools/dataset_analysis.py
@@ -8,10 +8,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 from mmengine.config import Config
 from mmengine.utils import ProgressBar
-from prettytable import PrettyTable
 
 from mmyolo.registry import DATASETS
 from mmyolo.utils import register_all_modules
+from mmyolo.utils.misc import (show_class_list, show_data_classes,
+                               show_data_list)
 
 
 def parse_args():
@@ -295,79 +296,6 @@ def show_bbox_area(args, fig_set, area_rule, class_name, bbox_area_num):
         pad_inches=0.1)  # Save Image
     plt.close()
     print(f'End and save in {out_dir}/{out_name}_bbox_area.jpg')
-
-
-def show_class_list(classes, class_num):
-    """Print the data of the class obtained by the current run."""
-    print('\n\nThe information obtained is as follows:')
-    class_info = PrettyTable()
-    class_info.title = 'Information of dataset class'
-    # List Print Settings
-    # If the quantity is too large, 25 rows will be displayed in each column
-    if len(classes) < 25:
-        class_info.add_column('Class name', classes)
-        class_info.add_column('Bbox num', class_num)
-    elif len(classes) % 25 != 0 and len(classes) > 25:
-        col_num = int(len(classes) / 25) + 1
-        class_nums = class_num.tolist()
-        class_name_list = list(classes)
-        for i in range(0, (col_num * 25) - len(classes)):
-            class_name_list.append('')
-            class_nums.append('')
-        for i in range(0, len(class_name_list), 25):
-            class_info.add_column('Class name', class_name_list[i:i + 25])
-            class_info.add_column('Bbox num', class_nums[i:i + 25])
-
-    # Align display data to the left
-    class_info.align['Class name'] = 'l'
-    class_info.align['Bbox num'] = 'l'
-    print(class_info)
-
-
-def show_data_list(args, area_rule):
-    """Print run setup information."""
-    print('\n\nPrint current running information:')
-    data_info = PrettyTable()
-    data_info.title = 'Dataset information'
-    # Print the corresponding information according to the settings
-    if args.val_dataset is False:
-        data_info.add_column('Dataset type', ['train_dataset'])
-    elif args.val_dataset is True:
-        data_info.add_column('Dataset type', ['val_dataset'])
-    if args.class_name is None:
-        data_info.add_column('Class name', ['All classes'])
-    else:
-        data_info.add_column('Class name', [args.class_name])
-    if args.func is None:
-        data_info.add_column('Function', ['All function'])
-    else:
-        data_info.add_column('Function', [args.func])
-    data_info.add_column('Area rule', [area_rule])
-
-    print(data_info)
-
-
-def show_data_classes(data_classes):
-    """When printing an error, all class names of the dataset."""
-    print('\n\nThe name of the class contained in the dataset:')
-    data_classes_info = PrettyTable()
-    data_classes_info.title = 'Information of dataset class'
-    # List Print Settings
-    # If the quantity is too large, 25 rows will be displayed in each column
-    if len(data_classes) < 25:
-        data_classes_info.add_column('Class name', data_classes)
-    elif len(data_classes) % 25 != 0 and len(data_classes) > 25:
-        col_num = int(len(data_classes) / 25) + 1
-        data_name_list = list(data_classes)
-        for i in range(0, (col_num * 25) - len(data_classes)):
-            data_name_list.append('')
-        for i in range(0, len(data_name_list), 25):
-            data_classes_info.add_column('Class name',
-                                         data_name_list[i:i + 25])
-
-    # Align display data to the left
-    data_classes_info.align['Class name'] = 'l'
-    print(data_classes_info)
 
 
 def main():


### PR DESCRIPTION
## Motivation

Add `--class-name` for filter when save to labelme label.

## Modification

`demo/image_demo.py`

## Command
```bash
python demo/image_demo.py \
         /data/cat/images \
         configs/yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py \
         work_dirs/yolov5_s-v61_syncbn_fast_8xb16-300e_coco_20220918_084700-86e02187.pth \
         --out-dir /data/cat/labels \
         --to-labelme \
         --class-name cat
```

## Json
![image](https://user-images.githubusercontent.com/25873202/203592521-2e41b2e7-5855-43df-8df4-78cd7102c154.png)

