### PR TITLE
[Fix] Fix mmyolo ut scope

### DIFF
--- a/tests/test_deploy/test_mmyolo_models.py
+++ b/tests/test_deploy/test_mmyolo_models.py
@@ -82,7 +82,7 @@ def test_yolov5_head_predict_by_feat(backend_type: Backend):
             backend_config=dict(type=backend_type.value),
             onnx_config=dict(output_names=output_names, input_shape=None),
             codebase_config=dict(
-                type='mmdet',
+                type='mmyolo',
                 task='ObjectDetection',
                 post_processing=dict(
                     score_threshold=0.05,

--- a/tests/test_deploy/test_object_detection.py
+++ b/tests/test_deploy/test_object_detection.py
@@ -37,7 +37,7 @@ deploy_cfg = Config(
     dict(
         backend_config=dict(type='onnxruntime'),
         codebase_config=dict(
-            type='mmdet',
+            type='mmyolo',
             task='ObjectDetection',
             post_processing=dict(
                 score_threshold=0.05,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix mmyolo ut wrong scope, this bug is exposed after [mmdeploy PR1450](https://github.com/open-mmlab/mmdeploy/pull/1450) merged in mmdeploy.

## Modification

mmyolo test_deploy folder, change type 'mmdet' to 'mmyolo'

## BC-breaking (Optional)

None.

## Use cases (Optional)

```bash
pytest tests/test_deploy
```

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
