### PR TITLE
[Feat]: support mmyolo regression test

### DIFF
--- a/configs/deploy/detection_tensorrt-fp16_dynamic-64x64-1344x1344.py
+++ b/configs/deploy/detection_tensorrt-fp16_dynamic-64x64-1344x1344.py
@@ -1,0 +1,13 @@
+_base_ = ['./base_dynamic.py']
+backend_config = dict(
+    type='tensorrt',
+    common_config=dict(fp16_mode=True, max_workspace_size=1 << 32),
+    model_inputs=[
+        dict(
+            input_shapes=dict(
+                input=dict(
+                    min_shape=[1, 3, 64, 64],
+                    opt_shape=[1, 3, 640, 640],
+                    max_shape=[1, 3, 1344, 1344])))
+    ])
+use_efficientnms = False  # whether to replace TRTBatchedNMS plugin with EfficientNMS plugin # noqa E501

--- a/tests/regression/mmyolo.yml
+++ b/tests/regression/mmyolo.yml
@@ -1,0 +1,81 @@
+globals:
+  codebase_dir: ../mmyolo
+  checkpoint_force_download: False
+  images:
+    input_img: &input_img ../mmyolo/demo/demo.jpg
+    test_img: &test_img ./tests/data/tiger.jpeg
+  metric_info: &metric_info
+    box AP: # named after metafile.Results.Metrics
+      metric_key: coco/bbox_mAP # eval OrderedDict key name
+      tolerance: 1 # metric ±n%
+      multi_value: 100
+  convert_image: &convert_image
+    input_img: *input_img
+    test_img: *test_img
+  backend_test: &default_backend_test True
+
+onnxruntime:
+  pipeline_ort_static_fp32: &pipeline_ort_static_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmyolo/detection_onnxruntime_static.py
+
+  pipeline_ort_dynamic_fp32: &pipeline_ort_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmyolo/detection_onnxruntime_dynamic.py
+
+tensorrt:
+  pipeline_trt_static_fp32: &pipeline_trt_static_fp32_640x640
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmyolo/detection_tensorrt_static-640x640.py
+
+  pipeline_trt_static_fp16: &pipeline_trt_static_fp16_640x640
+    convert_image: *convert_image
+    backend_test: False
+    deploy_config: configs/mmyolo/detection_tensorrt-fp16_static-640x640.py
+
+  pipeline_trt_dynamic_fp32: &pipeline_trt_dynamic_fp32
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmyolo/detection_tensorrt_dynamic-192x192-960x960.py
+
+  pipeline_trt_dynamic_fp16: &pipeline_trt_dynamic_fp16
+    convert_image: *convert_image
+    backend_test: *default_backend_test
+    deploy_config: configs/mmyolo/detection_tensorrt-fp16_dynamic-64x64-1344x1344.py
+
+models:
+  - name: YOLOv5
+    metafile: configs/yolov5/metafile.yml
+    model_configs:
+      - configs/yolov5/yolov5_s-p6-v62_syncbn_fast_8xb16-300e_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+
+  - name: YOLOv6
+    metafile: configs/yolov6/metafile.yml
+    model_configs:
+      - configs/yolov6/yolov6_s_syncbn_fast_8xb32-400e_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+
+  - name: YOLOX
+    metafile: configs/yolox/metafile.yml
+    model_configs:
+      - configs/yolox/yolox_s_8xb8-300e_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16
+
+
+  - name: RTMDet
+    metafile: configs/rtmdet/metafile.yml
+    model_configs:
+      - configs/rtmdet/rtmdet_s_syncbn_8xb32-300e_coco.py
+    pipelines:
+      - *pipeline_ort_dynamic_fp32
+      - *pipeline_trt_dynamic_fp16


### PR DESCRIPTION

## Motivation

support mmyolo regression test

## Modification

- add regression test yml config: `tests/regression/mmyolo.yml`
- add trt dynamic deploy config: `configs/deploy/detection_tensorrt-fp16_dynamic-64x64-1344x1344.py`

## BC-breaking (Optional)

None

## Use cases (Optional)

1. install mmdeploy
refer to https://mmdeploy.readthedocs.io/en/1.x/get_started.html#get-started
2. soft link files
```bash
ln -sf ${MMYOLO_DIR}/configs/deploy ${MMDEPLOY_DIR}/configs/mmyolo
ln -sf ${MMYOLO_DIR}/tests/regression/mmyolo.yml ${MMDEPLOY_DIR}/tests/regression/mmyolo.yml
```
3. test with mmdeploy
```
cd ${MMDEPLOY_DIR}
python tools/regression_test.py \
    --codebase mmyolo \
    --backends onnxruntime tensorrt \
    --performance \
    --work-dir test_mmyolo \
    --device cuda
```

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
5. The documentation has been modified accordingly, like docstring or example tutorials.
