### PR TITLE
[WIP] [Feature] Support benchmark

### DIFF
--- a/tools/analysis_tools/benchmark.py
+++ b/tools/analysis_tools/benchmark.py
@@ -159,6 +159,7 @@ def repeat_measure_inference_speed(cfg,
 def main():
     args = parse_args()
 
+    # support auto regression test.
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)


### PR DESCRIPTION
## Motivation

Add benchmark for MMYOLO and user


| config | COCO eval map | Train epoch    | Model param    | GFlops    | PyTorch eval FPS |
|----|-----|-----|-----|-----|-----|
|    |     |     |     |     |     |


1. user need to set up a `benchmark.yaml` for the script
2. the script will load the model and config path from `benchmark.yaml`
3. run eval for each model to get the info
4. save as a excel or markdown table.

## Modification

code: 
doc:
requirement:

## Use cases

```shell
python tools/analysis_tools/benchmark.py ${MODEL_YAML} --out-dir ${OU_DIR}
```
