### PR TITLE
[Fix] Fix CI error due to `np.int` and legacy builder.py

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -66,9 +66,9 @@ jobs:
           name: Install mmyolo dependencies
           command: |
             pip install -U openmim
-            mim install 'mmengine >= 0.3.1'
+            mim install git+https://github.com/open-mmlab/mmengine.git@main
             mim install 'mmcv >= 2.0.0rc1'
-            pip install git+https://github.com/open-mmlab/mmdetection.git@dev-3.x
+            mim install git+https://github.com/open-mmlab/mmdetection.git@dev-3.x
             pip install -r requirements/albu.txt
             pip install -r requirements/tests.txt
       - run:

--- a/docs/en/algorithm_descriptions/yolov5_description.md
+++ b/docs/en/algorithm_descriptions/yolov5_description.md
@@ -618,7 +618,7 @@ At the same time, the batch shape of the current batch is calculated to prevent 
 
         n = len(image_shapes)  # number of images
         batch_index = np.floor(np.arange(n) / self.batch_size).astype(
-            np.int)  # batch index
+            np.int64)  # batch index
         number_of_batches = batch_index[-1] + 1  # number of batches
 
         aspect_ratio = image_shapes[:, 1] / image_shapes[:, 0]  # aspect ratio
@@ -640,7 +640,7 @@ At the same time, the batch shape of the current batch is calculated to prevent 
 
         batch_shapes = np.ceil(
             np.array(shapes) * self.img_size / self.size_divisor +
-            self.pad).astype(np.int) * self.size_divisor
+            self.pad).astype(np.int64) * self.size_divisor
 
         for i, data_info in enumerate(data_list):
             data_info['batch_shape'] = batch_shapes[batch_index[i]]

--- a/docs/zh_cn/algorithm_descriptions/yolov5_description.md
+++ b/docs/zh_cn/algorithm_descriptions/yolov5_description.md
@@ -619,7 +619,7 @@ YOLOv5 是非解耦输出头，而其他大部分算法都是解耦输出头，�
 
         n = len(image_shapes)  # number of images
         batch_index = np.floor(np.arange(n) / self.batch_size).astype(
-            np.int)  # batch index
+            np.int64)  # batch index
         number_of_batches = batch_index[-1] + 1  # number of batches
 
         aspect_ratio = image_shapes[:, 1] / image_shapes[:, 0]  # aspect ratio
@@ -641,7 +641,7 @@ YOLOv5 是非解耦输出头，而其他大部分算法都是解耦输出头，�
 
         batch_shapes = np.ceil(
             np.array(shapes) * self.img_size / self.size_divisor +
-            self.pad).astype(np.int) * self.size_divisor
+            self.pad).astype(np.int64) * self.size_divisor
 
         for i, data_info in enumerate(data_list):
             data_info['batch_shape'] = batch_shapes[batch_index[i]]

--- a/mmyolo/datasets/utils.py
+++ b/mmyolo/datasets/utils.py
@@ -64,7 +64,7 @@ class BatchShapePolicy:
 
         n = len(image_shapes)  # number of images
         batch_index = np.floor(np.arange(n) / self.batch_size).astype(
-            np.int)  # batch index
+            np.int64)  # batch index
         number_of_batches = batch_index[-1] + 1  # number of batches
 
         aspect_ratio = image_shapes[:, 1] / image_shapes[:, 0]  # aspect ratio
@@ -86,7 +86,7 @@ class BatchShapePolicy:
 
         batch_shapes = np.ceil(
             np.array(shapes) * self.img_size / self.size_divisor +
-            self.extra_pad_ratio).astype(np.int) * self.size_divisor
+            self.extra_pad_ratio).astype(np.int64) * self.size_divisor
 
         for i, data_info in enumerate(data_list):
             data_info['batch_shape'] = batch_shapes[batch_index[i]]

--- a/mmyolo/utils/boxam_utils.py
+++ b/mmyolo/utils/boxam_utils.py
@@ -12,12 +12,13 @@ import torch.nn as nn
 import torchvision
 from mmcv.transforms import Compose
 from mmdet.evaluation import get_classes
-from mmdet.registry import MODELS
 from mmdet.utils import ConfigType
 from mmengine.config import Config
 from mmengine.runner import load_checkpoint
 from mmengine.structures import InstanceData
 from torch import Tensor
+
+from mmyolo.registry import MODELS
 
 try:
     from pytorch_grad_cam import (AblationCAM, AblationLayer,

--- a/mmyolo/utils/boxam_utils.py
+++ b/mmyolo/utils/boxam_utils.py
@@ -12,7 +12,7 @@ import torch.nn as nn
 import torchvision
 from mmcv.transforms import Compose
 from mmdet.evaluation import get_classes
-from mmdet.models import build_detector
+from mmdet.registry import MODELS
 from mmdet.utils import ConfigType
 from mmengine.config import Config
 from mmengine.runner import load_checkpoint
@@ -71,7 +71,7 @@ def init_detector(
     # grad based method requires train_cfg
     # config.model.train_cfg = None
 
-    model = build_detector(config.model)
+    model = MODELS.build(config.model)
     if checkpoint is not None:
         checkpoint = load_checkpoint(model, checkpoint, map_location='cpu')
         # Weights converted from elsewhere may not have meta fields.

--- a/tests/test_models/test_detectors/test_yolo_detector.py
+++ b/tests/test_models/test_detectors/test_yolo_detector.py
@@ -29,8 +29,8 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.models import build_detector
-        detector = build_detector(model)
+        from mmdet.registry import MODELS
+        detector = MODELS.build(model)
         self.assertTrue(detector.backbone)
         self.assertTrue(detector.neck)
         self.assertTrue(detector.bbox_head)
@@ -56,11 +56,11 @@ class TestSingleStageDetector(TestCase):
                 std=[255., 255., 255.],
                 bgr_to_rgb=True)
 
-        from mmdet.models import build_detector
+        from mmdet.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:
-            detector = build_detector(model)
+            detector = MODELS.build(model)
             detector.init_weights()
 
             if device == 'cuda':
@@ -85,11 +85,11 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.models import build_detector
+        from mmdet.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:
-            detector = build_detector(model)
+            detector = MODELS.build(model)
 
             if device == 'cuda':
                 if not torch.cuda.is_available():
@@ -117,11 +117,11 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.models import build_detector
+        from mmdet.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:
-            detector = build_detector(model)
+            detector = MODELS.build(model)
 
             if device == 'cuda':
                 if not torch.cuda.is_available():

--- a/tests/test_models/test_detectors/test_yolo_detector.py
+++ b/tests/test_models/test_detectors/test_yolo_detector.py
@@ -29,7 +29,7 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.registry import MODELS
+        from mmyolo.registry import MODELS
         detector = MODELS.build(model)
         self.assertTrue(detector.backbone)
         self.assertTrue(detector.neck)
@@ -56,7 +56,7 @@ class TestSingleStageDetector(TestCase):
                 std=[255., 255., 255.],
                 bgr_to_rgb=True)
 
-        from mmdet.registry import MODELS
+        from mmyolo.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:
@@ -85,7 +85,7 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.registry import MODELS
+        from mmyolo.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:
@@ -117,7 +117,7 @@ class TestSingleStageDetector(TestCase):
         model = get_detector_cfg(cfg_file)
         model.backbone.init_cfg = None
 
-        from mmdet.registry import MODELS
+        from mmyolo.registry import MODELS
         assert all([device in ['cpu', 'cuda'] for device in devices])
 
         for device in devices:

--- a/tools/analysis_tools/benchmark.py
+++ b/tools/analysis_tools/benchmark.py
@@ -5,7 +5,7 @@ import os
 import time
 
 import torch
-from mmdet.models import build_detector
+from mmdet.registry import MODELS
 from mmengine import Config, DictAction
 from mmengine.dist import get_world_size, init_dist
 from mmengine.logging import MMLogger, print_log
@@ -82,7 +82,7 @@ def measure_inference_speed(cfg, checkpoint, max_iter, log_interval,
     data_loader = Runner.build_dataloader(dataloader_cfg)
 
     # build the model and load checkpoint
-    model = build_detector(cfg.model)
+    model = MODELS.build(cfg.model)
     load_checkpoint(model, checkpoint, map_location='cpu')
     model = model.cuda()
     model.eval()

--- a/tools/analysis_tools/benchmark.py
+++ b/tools/analysis_tools/benchmark.py
@@ -5,7 +5,6 @@ import os
 import time
 
 import torch
-from mmdet.registry import MODELS
 from mmengine import Config, DictAction
 from mmengine.dist import get_world_size, init_dist
 from mmengine.logging import MMLogger, print_log
@@ -13,6 +12,7 @@ from mmengine.runner import Runner, load_checkpoint
 from mmengine.utils import mkdir_or_exist
 from mmengine.utils.dl_utils import set_multi_processing
 
+from mmyolo.registry import MODELS
 from mmyolo.utils import register_all_modules
 
 register_all_modules()


### PR DESCRIPTION
## Motivation

Fix CI error due to `np.int` and legacy builder.py, https://github.com/open-mmlab/mmdetection/pull/9479

## Modification

1. Replace all `np.int` with `np.int64`.
2. Replace all `build_detector` with `MODELS.build`.
3. Using the `main` branch of mmengine instead of the tag version in CI.