### PR TITLE
[Enhancement] Remove 'context' argument from the rewriter function to 'YOLOv5Head.p…

### DIFF
--- a/mmyolo/deploy/models/dense_heads/yolov5_head.py
+++ b/mmyolo/deploy/models/dense_heads/yolov5_head.py
@@ -37,8 +37,7 @@ def yolov5_bbox_decoder(priors, bbox_preds, stride):
 @FUNCTION_REWRITER.register_rewriter(
     func_name='mmyolo.models.dense_heads.yolov5_head.'
     'YOLOv5Head.predict_by_feat')
-def yolov5_head__predict_by_feat(ctx,
-                                 self,
+def yolov5_head__predict_by_feat(self,
                                  cls_scores: List[Tensor],
                                  bbox_preds: List[Tensor],
                                  objectnesses: Optional[List[Tensor]] = None,
@@ -74,6 +73,7 @@ def yolov5_head__predict_by_feat(ctx,
             tensor in the tuple is (N, num_box), and each element
             represents the class label of the corresponding box.
     """
+    ctx = FUNCTION_REWRITER.get_context()
     detector_type = type(self)
     deploy_cfg = ctx.cfg
     use_efficientnms = deploy_cfg.get('use_efficientnms', False)
@@ -170,8 +170,7 @@ def yolov5_head__predict__rknn(ctx, self, x: Tuple[Tensor], *args,
     'YOLOv5HeadModule.forward',
     backend='rknn')
 def yolov5_head_module__forward__rknn(
-        ctx, self, x: Tensor, *args,
-        **kwargs) -> Tuple[Tensor, Tensor, Tensor]:
+        self, x: Tensor, *args, **kwargs) -> Tuple[Tensor, Tensor, Tensor]:
     """Forward feature of a single scale level."""
     out = []
     for i, feat in enumerate(x):


### PR DESCRIPTION
…redict_by_feat' since mmdeploy has refactored it

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMDeploy has refactored the rewriter function signature to support MMRazor, referring to https://github.com/open-mmlab/mmdeploy/pull/1483, 
in which the context argument has been removed from the argument list and can be retrieved by `ctx = FUNCTION_REWRITER.get_context()`

## Modification

the rewriter function to `YOLOv5Head.predict_by_feat`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
