### PR TITLE
[Fix] Deprecating `np.bool` Type Alias

### DIFF
--- a/mmyolo/datasets/transforms/mix_img_transforms.py
+++ b/mmyolo/datasets/transforms/mix_img_transforms.py
@@ -221,7 +221,7 @@ class Mosaic(BaseMixImageTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
     Modified Keys:
@@ -504,7 +504,7 @@ class Mosaic9(BaseMixImageTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
     Modified Keys:
@@ -776,7 +776,7 @@ class YOLOv5MixUp(BaseMixImageTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
 
@@ -917,7 +917,7 @@ class YOLOXMixUp(BaseMixImageTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
 

--- a/mmyolo/datasets/transforms/transforms.py
+++ b/mmyolo/datasets/transforms/transforms.py
@@ -410,7 +410,7 @@ class YOLOv5RandomAffine(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 

--- a/tools/analysis_tools/browse_dataset.py
+++ b/tools/analysis_tools/browse_dataset.py
@@ -218,7 +218,7 @@ def main():
             gt_masks = gt_instances.get('masks', None)
             if gt_masks is not None:
                 masks = mask2ndarray(gt_masks)
-                gt_instances.masks = masks.astype(np.bool)
+                gt_instances.masks = masks.astype(bool)
                 datasample.gt_instances = gt_instances
             # get filename from dataset or just use index as filename
             visualizer.add_datasample(


### PR DESCRIPTION
## Motivation

`np.bool` is a deprecated alias for the builtin bool and it was removed in https://github.com/numpy/numpy/releases/tag/v1.24.0 .

## Modification

Replace all `np.bool` with `bool`.