### PR TITLE
Fix the device inconsistency error in yolov7 training

### DIFF
--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -277,7 +277,7 @@ class BatchYOLOv7Assigner(nn.Module):
                 self.iou_weight * pair_wise_iou_loss)
 
             # num_gt, num_match_pred
-            matching_matrix = torch.zeros_like(cost)
+            matching_matrix = torch.zeros_like(cost, device=_from_which_layer.device) 
 
             top_k, _ = torch.topk(
                 pair_wise_iou,

--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -197,6 +197,8 @@ class BatchYOLOv7Assigner(nn.Module):
             _mlvl_priors = []
             _mlvl_positive_infos = []
             _from_which_layer = []
+            
+            device_tensor = torch.ones([1,], device=pred_results[0].device)
 
             for i, head_pred in enumerate(pred_results):
                 # (num_matched_target, 4)
@@ -213,7 +215,7 @@ class BatchYOLOv7Assigner(nn.Module):
                 _mlvl_priors.append(priors)
 
                 _from_which_layer.append(
-                    torch.ones(size=(_mlvl_positive_info.shape[0], )) * i)
+                    device_tensor.new_full(size=(_mlvl_positive_info.shape[0], ), fill_value=i))
 
                 # (n,85)
                 level_batch_idx, prior_ind, \
@@ -277,8 +279,7 @@ class BatchYOLOv7Assigner(nn.Module):
                 self.iou_weight * pair_wise_iou_loss)
 
             # num_gt, num_match_pred
-            matching_matrix = torch.zeros_like(
-                cost, device=_from_which_layer.device)
+            matching_matrix = torch.zeros_like(cost)
 
             top_k, _ = torch.topk(
                 pair_wise_iou,

--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -277,7 +277,8 @@ class BatchYOLOv7Assigner(nn.Module):
                 self.iou_weight * pair_wise_iou_loss)
 
             # num_gt, num_match_pred
-            matching_matrix = torch.zeros_like(cost, device=_from_which_layer.device) 
+            matching_matrix = torch.zeros_like(
+                cost, device=_from_which_layer.device)
 
             top_k, _ = torch.topk(
                 pair_wise_iou,

--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -198,8 +198,6 @@ class BatchYOLOv7Assigner(nn.Module):
             _mlvl_positive_infos = []
             _from_which_layer = []
 
-            device_tensor = torch.tensor(1, device='cuda')
-
             for i, head_pred in enumerate(pred_results):
                 # (num_matched_target, 4)
                 #  4 is mean (batch_idx, prior_idx, grid_x, grid_y)
@@ -215,7 +213,7 @@ class BatchYOLOv7Assigner(nn.Module):
                 _mlvl_priors.append(priors)
 
                 _from_which_layer.append(
-                    device_tensor.new_full(
+                    _mlvl_positive_info.new_full(
                         size=(_mlvl_positive_info.shape[0], ), fill_value=i))
 
                 # (n,85)

--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -197,8 +197,8 @@ class BatchYOLOv7Assigner(nn.Module):
             _mlvl_priors = []
             _mlvl_positive_infos = []
             _from_which_layer = []
-            
-            device_tensor = torch.ones([1,], device=pred_results[0].device)
+
+            device_tensor = torch.Tensor(1, device='cuda')
 
             for i, head_pred in enumerate(pred_results):
                 # (num_matched_target, 4)
@@ -215,7 +215,8 @@ class BatchYOLOv7Assigner(nn.Module):
                 _mlvl_priors.append(priors)
 
                 _from_which_layer.append(
-                    device_tensor.new_full(size=(_mlvl_positive_info.shape[0], ), fill_value=i))
+                    device_tensor.new_full(
+                        size=(_mlvl_positive_info.shape[0], ), fill_value=i))
 
                 # (n,85)
                 level_batch_idx, prior_ind, \

--- a/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
+++ b/mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py
@@ -198,7 +198,7 @@ class BatchYOLOv7Assigner(nn.Module):
             _mlvl_positive_infos = []
             _from_which_layer = []
 
-            device_tensor = torch.Tensor(1, device='cuda')
+            device_tensor = torch.tensor(1, device='cuda')
 
             for i, head_pred in enumerate(pred_results):
                 # (num_matched_target, 4)


### PR DESCRIPTION
# Motivation
when training custom data with yolov7,  it give [RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)]. The same problem was shown [stackoverflow](https://stackoverflow.com/questions/74713315/yolov7-runtimeerror-indices-should-be-either-on-cpu-or-on-the-same-device-as) and [official yolov7 issue#1224](https://github.com/WongKinYiu/yolov7/issues/1224)
The cause seems to be that in `mmyolo/models/task_modules/assigners/batch_yolov7_assigner.py ` line 309 `_from_which_layer = _from_which_layer[fg_mask_inboxes]`, the indices`fg_mask_inboxes` and `_from_which_layer` are not in the same device. 

sys.platform: linux
Python: 3.9.15 (main, Nov 24 2022, 14:31:59) [GCC 11.2.0]
CUDA available: True
numpy_random_seed: 2147483648
GPU 0,1,2: Tesla T4
CUDA_HOME: /home/zbc/miniconda3/envs/test
NVCC: Cuda compilation tools, release 11.6, V11.6.124
GCC: gcc (GCC) 8.3.1 20190311 (Red Hat 8.3.1-3)
PyTorch: 1.13.1
PyTorch compiling details: PyTorch built with:
  - GCC 9.3
  - C++ Version: 201402
  - Intel(R) oneAPI Math Kernel Library Version 2021.4-Product Build 20210904 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v2.6.0 (Git Hash 52b5f107dd9cf10910aaa19cb47f3abf9b349815)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - LAPACK is enabled (usually provided by MKL)
  - NNPACK is enabled
  - CPU capability usage: AVX2
  - CUDA Runtime 11.6
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_61,code=sm_61;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_37,code=compute_37
  - CuDNN 8.3.2  (built against CUDA 11.5)
  - Magma 2.6.1
  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CUDA_VERSION=11.6, CUDNN_VERSION=8.3.2, CXX_COMPILER=/opt/rh/devtoolset-9/root/usr/bin/c++, CXX_FLAGS= -fabi-version=11 -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp -DNDEBUG -DUSE_KINETO -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -DEDGE_PROFILER_USE_KINETO -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Werror=non-virtual-dtor -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wunused-local-typedefs -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-psabi -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Werror=cast-function-type -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, TORCH_VERSION=1.13.1, USE_CUDA=ON, USE_CUDNN=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=ON, USE_NNPACK=ON, USE_OPENMP=ON, USE_ROCM=OFF, 

TorchVision: 0.14.1
OpenCV: 4.6.0
MMEngine: 0.3.2
MMCV: 2.0.0rc3
MMDetection: 3.0.0rc4
MMYOLO: 0.2.0+27487fd

In the commet of [this blog](https://blog.csdn.net/weixin_44270070/article/details/127657478), one says an easy downgrade of pytorch and cuda from `pytorch1.13 cu117` to `pytorch1.7 cu110` could solve this problem.
# Modification
move `matching_matrix` to the same device of `_from_which_layer` 