### PR TITLE
Fix test pipeline in configs

### DIFF
--- a/configs/deploy/model/yolov5_s-static.py
+++ b/configs/deploy/model/yolov5_s-static.py
@@ -2,13 +2,13 @@ _base_ = '../../yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/deploy/model/yolov6_s-static.py
+++ b/configs/deploy/model/yolov6_s-static.py
@@ -2,13 +2,13 @@ _base_ = '../../yolov6/yolov6_s_syncbn_fast_8xb32-400e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/ppyoloe/ppyoloe_plus_s_fast_8xb8-80e_coco.py
+++ b/configs/ppyoloe/ppyoloe_plus_s_fast_8xb8-80e_coco.py
@@ -158,13 +158,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.FixShapeResize',
         width=img_scale[0],
         height=img_scale[1],
         keep_ratio=False,
         interpolation='bicubic'),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/rtmdet/rtmdet_l_syncbn_fast_8xb32-300e_coco.py
+++ b/configs/rtmdet/rtmdet_l_syncbn_fast_8xb32-300e_coco.py
@@ -139,13 +139,13 @@ train_pipeline_stage2 = [
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov5/voc/yolov5_s-v61_fast_1xb64-50e_voc.py
+++ b/configs/yolov5/voc/yolov5_s-v61_fast_1xb64-50e_voc.py
@@ -167,13 +167,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov5/yolov5_s-p6-v62_syncbn_fast_8xb16-300e_coco.py
+++ b/configs/yolov5/yolov5_s-p6-v62_syncbn_fast_8xb16-300e_coco.py
@@ -84,13 +84,13 @@ train_dataloader = dict(dataset=dict(pipeline=train_pipeline))
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py
+++ b/configs/yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py
@@ -212,13 +212,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov6/yolov6_s_syncbn_fast_8xb32-400e_coco.py
+++ b/configs/yolov6/yolov6_s_syncbn_fast_8xb32-400e_coco.py
@@ -169,13 +169,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov7/yolov7_l_syncbn_fast_8x16b-300e_coco.py
+++ b/configs/yolov7/yolov7_l_syncbn_fast_8x16b-300e_coco.py
@@ -184,13 +184,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov7/yolov7_w-p6_syncbn_fast_8x16b-300e_coco.py
+++ b/configs/yolov7/yolov7_w-p6_syncbn_fast_8x16b-300e_coco.py
@@ -99,13 +99,13 @@ train_dataloader = dict(dataset=dict(pipeline=train_pipeline))
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolov8/yolov8_s_syncbn_fast_8xb16-500e_coco.py
+++ b/configs/yolov8/yolov8_s_syncbn_fast_8xb16-500e_coco.py
@@ -246,13 +246,13 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolox/yolox_s_8xb8-300e_coco.py
+++ b/configs/yolox/yolox_s_8xb8-300e_coco.py
@@ -168,12 +168,12 @@ train_dataloader = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='mmdet.Resize', scale=img_scale, keep_ratio=True),
     dict(
         type='mmdet.Pad',
         pad_to_square=True,
         pad_val=dict(img=(114.0, 114.0, 114.0))),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/configs/yolox/yolox_tiny_8xb8-300e_coco.py
+++ b/configs/yolox/yolox_tiny_8xb8-300e_coco.py
@@ -45,12 +45,12 @@ train_pipeline_stage1 = [
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='mmdet.Resize', scale=(416, 416), keep_ratio=True),  # note
     dict(
         type='mmdet.Pad',
         pad_to_square=True,
         pad_val=dict(img=(114.0, 114.0, 114.0))),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/en/algorithm_descriptions/yolov8_description.md
+++ b/docs/en/algorithm_descriptions/yolov8_description.md
@@ -202,8 +202,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/en/deploy/basic_deployment_guide.md
+++ b/docs/en/deploy/basic_deployment_guide.md
@@ -62,13 +62,13 @@ _base_ = '../../yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/en/deploy/yolov5_deployment.md
+++ b/docs/en/deploy/yolov5_deployment.md
@@ -29,13 +29,13 @@ _base_ = '../../yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -114,13 +114,13 @@ batch_shapes_cfg = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/en/user_guides/visualization.md
+++ b/docs/en/user_guides/visualization.md
@@ -91,13 +91,13 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -112,8 +112,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change the  LetterResize to mmdet.Resize
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change the  LetterResize to mmdet.Resize
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -198,13 +198,13 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -219,8 +219,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change the  LetterResize to mmdet.Resize
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # change the  LetterResize to mmdet.Resize
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/zh_cn/algorithm_descriptions/yolov8_description.md
+++ b/docs/zh_cn/algorithm_descriptions/yolov8_description.md
@@ -204,8 +204,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/zh_cn/deploy/basic_deployment_guide.md
+++ b/docs/zh_cn/deploy/basic_deployment_guide.md
@@ -62,13 +62,13 @@ _base_ = '../../yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/zh_cn/deploy/yolov5_deployment.md
+++ b/docs/zh_cn/deploy/yolov5_deployment.md
@@ -29,13 +29,13 @@ _base_ = '../../yolov5/yolov5_s-v61_syncbn_8xb16-300e_coco.py'
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='LetterResize',
         scale=_base_.img_scale,
         allow_scale_up=False,
         use_mini_pad=False,
     ),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -114,13 +114,13 @@ batch_shapes_cfg = dict(
 
 test_pipeline = [
     dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',

--- a/docs/zh_cn/user_guides/visualization.md
+++ b/docs/zh_cn/user_guides/visualization.md
@@ -92,13 +92,13 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args={{_base_.file_client_args}}),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -113,8 +113,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -198,13 +198,13 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(type='YOLOv5KeepRatioResize', scale=img_scale),
     dict(
         type='LetterResize',
         scale=img_scale,
         allow_scale_up=False,
         pad_val=dict(img=114)),
-    dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
@@ -219,8 +219,8 @@ test_pipeline = [
     dict(
         type='LoadImageFromFile',
         file_client_args=_base_.file_client_args),
-    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(type='LoadAnnotations', with_bbox=True, _scope_='mmdet'),
+    dict(type='mmdet.Resize', scale=img_scale, keep_ratio=False), # 这里将 LetterResize 修改成 mmdet.Resize
     dict(
         type='mmdet.PackDetInputs',
         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',


### PR DESCRIPTION
## Motivation

Currently, all val and test pipelines load annotations in a wrong way. To see this, I've used the following script:

```
python tools/analysis_tools/browse_dataset.py configs/yolox/yolox_s_8xb8-300e_coco.py  --out-dir ./vis --phase val -n 10
```

Any config can be used, but for demonstration I've chosen yolox. As a result, we see wrong bounding boxes:

![before](https://user-images.githubusercontent.com/7460322/217265795-51d7b0b0-a025-458d-b974-2a2477b8b46c.jpg)

## Modification

The bug is caused by wrong order of `LoadAnnotation` stage in the val pipeline. It should be performed right after `LoadImageFromFile` stage. I've modified all configs and relevant docs to fix the bug:

![after](https://user-images.githubusercontent.com/7460322/217266596-7ecdcee5-3f3c-429b-8374-5fc15f8b2ac1.jpg)


## Checklist

- [x] Pre-commit or other linting tools are used to fix potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
