### PR TITLE
[Docs] add deploy doc to 15_min_od tutorial

### DIFF
--- a/docs/zh_cn/get_started/15_minutes_object_detection.md
+++ b/docs/zh_cn/get_started/15_minutes_object_detection.md
@@ -453,7 +453,7 @@ python projects/easydeploy/tools/image-demo.py \
 <img src="https://user-images.githubusercontent.com/7219519/220801159-ae550fd9-8ef9-4236-81e2-0eb16aa0d8cf.jpg" width="800" alt="image"/>
 </div>
 
-我们继续转换对应 TensorRT 的 engine 文件，因为 TensorRT 需要对应当前环境以及部署使用的版本进行，所以一定要确认导出参数，这里我们导出对应 TensorRT8 版本的文件，`--backend` 为2。
+我们继续转换对应 TensorRT 的 engine 文件，因为 TensorRT 需要对应当前环境以及部署使用的版本进行，所以一定要确认导出参数，这里我们导出对应 TensorRT8 版本的文件，`--backend` 为 2。
 
 ```shell
 python projects/easydeploy/tools/export.py \

--- a/docs/zh_cn/get_started/15_minutes_object_detection.md
+++ b/docs/zh_cn/get_started/15_minutes_object_detection.md
@@ -408,7 +408,7 @@ python demo/boxam_vis_demo.py data/cat/images/IMG_20221020_112705.jpg \
 
 此处我们将通过 MMYOLO 的 [EasyDeploy](../../../projects/easydeploy/) 来演示模型的转换部署和基本推理。
 
-首先需要在当前 MMYOLO 的虚拟环境中按照 EasyDeploy 的[基本文档](../../../projects/easydeploy/docs/model_convert.md) 对照自己的设备安装好所需的各个库。
+首先需要在当前 MMYOLO 的虚拟环境中按照 EasyDeploy 的 [基本文档](../../../projects/easydeploy/docs/model_convert.md) 对照自己的设备安装好所需的各个库。
 
 ```shell
 pip install onnx
@@ -416,7 +416,7 @@ pip install onnx-simplifier # 如果需要使用 simplify 功能需要安装
 pip install tensorrt        # 如果有 GPU 环境并且需要输出 TensorRT 模型需要继续执行
 ```
 
-完成安装后就可以用以下命令对已经训练好的针对 cat 数据集的模型一键转换部署，具体的各项参数含义和参数值需要对照使用的 config 文件进行调整。此处我们先导出 CPU 版本的 ONNX 模型，`--backend` 为 1。
+完成安装后就可以用以下命令对已经训练好的针对 cat 数据集的模型一键转换部署，当前设备的 ONNX 版本为 1.13.0，TensorRT 版本为 8.5.3.1，故可保持 `--opset` 为 11，其余各项参数的具体含义和参数值需要对照使用的 config 文件进行调整。此处我们先导出 CPU 版本的 ONNX 模型，`--backend` 为 1。
 
 ```shell
 python projects/easydeploy/tools/export.py \
@@ -447,10 +447,10 @@ python projects/easydeploy/tools/image-demo.py \
     --device cpu
 ```
 
-成功完成推理后会在默认的 MMYOLO 根目录下的 `output` 文件夹生成推理结果图，如果想直观看到结果而不需要保存，可以在上述命令结尾加上 `--show` 。
+成功完成推理后会在默认的 MMYOLO 根目录下的 `output` 文件夹生成推理结果图，如果想直观看到结果而不需要保存，可以在上述命令结尾加上 `--show` ，为了方便展示，下图是生成结果的截取部分。
 
 <div align=center>
-<img src="https://user-images.githubusercontent.com/7219519/220801159-ae550fd9-8ef9-4236-81e2-0eb16aa0d8cf.jpg" width="800" alt="image"/>
+<img src="https://user-images.githubusercontent.com/7219519/221061210-b91e0b5b-652d-4dfc-8451-86a9a36f7d04.png" width="800" alt="image"/>
 </div>
 
 我们继续转换对应 TensorRT 的 engine 文件，因为 TensorRT 需要对应当前环境以及部署使用的版本进行，所以一定要确认导出参数，这里我们导出对应 TensorRT8 版本的文件，`--backend` 为 2。
@@ -511,10 +511,10 @@ python projects/easydeploy/tools/image-demo.py \
     --device cuda:0
 ```
 
-此处依旧选择在 `output` 下保存推理结果而非直接显示结果，结果如图：
+此处依旧选择在 `output` 下保存推理结果而非直接显示结果，同样为了方便展示，下图是生成结果的截取部分。
 
 <div align=center>
-<img src="https://user-images.githubusercontent.com/7219519/220810115-b0d7eada-b04c-4271-8982-12ee2aa5f6a9.jpg" width="800" alt="image"/>
+<img src="https://user-images.githubusercontent.com/7219519/221061291-e7490bb6-5f0c-45ab-9fc4-caf2b62419d6.png" width="800" alt="image"/>
 </div>
 
 这样我们就完成了将训练完成的模型进行转换部署并且检查推理结果的工作。至此本教程结束。

--- a/docs/zh_cn/get_started/15_minutes_object_detection.md
+++ b/docs/zh_cn/get_started/15_minutes_object_detection.md
@@ -406,6 +406,117 @@ python demo/boxam_vis_demo.py data/cat/images/IMG_20221020_112705.jpg \
 
 ## EasyDeploy 模型部署
 
-TODO
+此处我们将通过 MMYOLO 的 [EasyDeploy](../../../projects/easydeploy/) 来演示模型的转换部署和基本推理。
+
+首先需要在当前 MMYOLO 的虚拟环境中按照 EasyDeploy 的[基本文档](../../../projects/easydeploy/docs/model_convert.md) 对照自己的设备安装好所需的各个库。
+
+```shell
+pip install onnx
+pip install onnx-simplifier # 如果需要使用 simplify 功能需要安装
+pip install tensorrt        # 如果有 GPU 环境并且需要输出 TensorRT 模型需要继续执行
+```
+
+完成安装后就可以用以下命令对已经训练好的针对 cat 数据集的模型一键转换部署，具体的各项参数含义和参数值需要对照使用的 config 文件进行调整。此处我们先导出 CPU 版本的 ONNX 模型，`--backend` 为 1。
+
+```shell
+python projects/easydeploy/tools/export.py \
+	configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
+	work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \
+	--work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \
+    --img-size 640 640 \
+    --batch 1 \
+    --device cpu \
+    --simplify \
+	--opset 11 \
+	--backend 1 \
+	--pre-topk 1000 \
+	--keep-topk 100 \
+	--iou-threshold 0.65 \
+	--score-threshold 0.25
+```
+
+成功运行后就可以在 `work-dir` 下得到转换后的 ONNX 模型，默认使用 `end2end.onnx` 命名。
+
+接下来我们使用此 `end2end.onnx` 模型来进行一个基本的图片推理:
+
+```shell
+python projects/easydeploy/tools/image-demo.py \
+    data/cat/images/IMG_20210728_205312.jpg \
+    configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
+    work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.onnx \
+    --device cpu
+```
+
+成功完成推理后会在默认的 MMYOLO 根目录下的 `output` 文件夹生成推理结果图，如果想直观看到结果而不需要保存，可以在上述命令结尾加上 `--show` 。
+
+<div align=center>
+<img src="https://user-images.githubusercontent.com/7219519/220801159-ae550fd9-8ef9-4236-81e2-0eb16aa0d8cf.jpg" width="800" alt="image"/>
+</div>
+
+我们继续转换对应 TensorRT 的 engine 文件，因为 TensorRT 需要对应当前环境以及部署使用的版本进行，所以一定要确认导出参数，这里我们导出对应 TensorRT8 版本的文件，`--backend` 为2。
+
+```shell
+python projects/easydeploy/tools/export.py \
+    configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
+    work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \
+    --work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \
+    --img-size 640 640 \
+    --batch 1 \
+    --device cuda:0 \
+    --simplify \
+    --opset 11 \
+    --backend 2 \
+    --pre-topk 1000 \
+    --keep-topk 100 \
+    --iou-threshold 0.65 \
+    --score-threshold 0.25
+```
+
+成功执行后得到的 `end2end.onnx` 就是对应 TensorRT8 部署需要的 ONNX 文件，我们使用这个文件完成 TensorRT engine 的转换。
+
+```shell
+python projects/easydeploy/tools/build_engine.py \
+    work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.onnx \
+    --img-size 640 640 \
+    --device cuda:0
+```
+
+成功执行后会在 `work-dir` 下生成 `end2end.engine` 文件：
+
+```shell
+work_dirs/yolov5_s-v61_fast_1xb12-40e_cat
+├── 202302XX_XXXXXX
+│   ├── 202302XX_XXXXXX.log
+│   └── vis_data
+│       ├── 202302XX_XXXXXX.json
+│       ├── config.py
+│       └── scalars.json
+├── best_coco
+│   └── bbox_mAP_epoch_40.pth
+├── end2end.engine
+├── end2end.onnx
+├── epoch_30.pth
+├── epoch_40.pth
+├── last_checkpoint
+└── yolov5_s-v61_fast_1xb12-40e_cat.py
+```
+
+我们继续使用 `image-demo.py` 进行图片推理：
+
+```shell
+python projects/easydeploy/tools/image-demo.py \
+    data/cat/images/IMG_20210728_205312.jpg \
+    configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
+    work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.engine \
+    --device cuda:0
+```
+
+此处依旧选择在 `output` 下保存推理结果而非直接显示结果，结果如图：
+
+<div align=center>
+<img src="https://user-images.githubusercontent.com/7219519/220810115-b0d7eada-b04c-4271-8982-12ee2aa5f6a9.jpg" width="800" alt="image"/>
+</div>
+
+这样我们就完成了将训练完成的模型进行转换部署并且检查推理结果的工作。至此本教程结束。
 
 以上完整内容可以查看 [15_minutes_object_detection.ipynb](<>)

--- a/projects/easydeploy/tools/image-demo.py
+++ b/projects/easydeploy/tools/image-demo.py
@@ -22,7 +22,7 @@ def parse_args():
     parser.add_argument(
         'img', help='Image path, include image file, dir and URL.')
     parser.add_argument('config', help='Config file')
-    parser.add_argument('checkpoint', help='Checkpoint file')
+    parser.add_argument('model', help='Exported model file')
     parser.add_argument(
         '--out-dir', default='./output', help='Path to output file')
     parser.add_argument(
@@ -62,12 +62,11 @@ def main():
 
     colors = [[random.randint(0, 255) for _ in range(3)] for _ in range(1000)]
 
-    # build the model from a config file and a checkpoint file
-    if args.checkpoint.endswith('.onnx'):
-        model = ORTWrapper(args.checkpoint, args.device)
-    elif args.checkpoint.endswith('.engine') or args.checkpoint.endswith(
-            '.plan'):
-        model = TRTWrapper(args.checkpoint, args.device)
+    # build the model from a config file and a model file
+    if args.model.endswith('.onnx'):
+        model = ORTWrapper(args.model, args.device)
+    elif args.model.endswith('.engine') or args.model.endswith('.plan'):
+        model = TRTWrapper(args.model, args.device)
     else:
         raise NotImplementedError
 

--- a/projects/easydeploy/tools/image-demo.py
+++ b/projects/easydeploy/tools/image-demo.py
@@ -22,7 +22,7 @@ def parse_args():
     parser.add_argument(
         'img', help='Image path, include image file, dir and URL.')
     parser.add_argument('config', help='Config file')
-    parser.add_argument('model', help='Exported model file')
+    parser.add_argument('checkpoint', help='Checkpoint file')
     parser.add_argument(
         '--out-dir', default='./output', help='Path to output file')
     parser.add_argument(
@@ -62,11 +62,12 @@ def main():
 
     colors = [[random.randint(0, 255) for _ in range(3)] for _ in range(1000)]
 
-    # build the model from a config file and a model file
-    if args.model.endswith('.onnx'):
-        model = ORTWrapper(args.model, args.device)
-    elif args.model.endswith('.engine') or args.model.endswith('.plan'):
-        model = TRTWrapper(args.model, args.device)
+    # build the model from a config file and a checkpoint file
+    if args.checkpoint.endswith('.onnx'):
+        model = ORTWrapper(args.checkpoint, args.device)
+    elif args.checkpoint.endswith('.engine') or args.checkpoint.endswith(
+            '.plan'):
+        model = TRTWrapper(args.checkpoint, args.device)
     else:
         raise NotImplementedError
 
@@ -124,15 +125,16 @@ def main():
         for (bbox, score, label) in zip(bboxes, scores, labels):
             bbox = bbox.tolist()
             color = colors[label]
-            name = f'cls:{label}_score:{score:0.4f}'
+            label_name = cfg.get('class_name', {})[label]
+            name = f'cls:{label_name}_score:{score:0.4f}'
 
             cv2.rectangle(bgr, bbox[:2], bbox[2:], color, 2)
             cv2.putText(
                 bgr,
                 name, (bbox[0], bbox[1] - 2),
                 cv2.FONT_HERSHEY_SIMPLEX,
-                0.75, [225, 255, 255],
-                thickness=2)
+                2.0, [225, 255, 255],
+                thickness=3)
 
         if args.show:
             mmcv.imshow(bgr, 'result', 0)


### PR DESCRIPTION
## Motivation

增加使用 EasyDeploy 完成 ONNX 和 TensorRT 转换部署和基本图片推理的文档

## Modification

docs/zh_cn/get_started/15_minutes_object_detection.md
projects/easydeploy/tools/image-demo.py


## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
