### PR TITLE
[Fix] Fix typos in the YOLOv8 diagram

### DIFF
--- a/configs/yolov8/README.md
+++ b/configs/yolov8/README.md
@@ -12,7 +12,7 @@ YOLOv8 performance
 </div>
 
 <div align=center>
-<img src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
+<img src="https://user-images.githubusercontent.com/27466624/222869864-1955f054-aa6d-4a80-aed3-92f30af28849.jpg"/>
 YOLOv8-P5 model structure
 </div>
 

--- a/configs/yolov8/README.md
+++ b/configs/yolov8/README.md
@@ -8,11 +8,11 @@ Ultralytics YOLOv8, developed by Ultralytics, is a cutting-edge, state-of-the-ar
 
 <div align=center>
 <img src="https://user-images.githubusercontent.com/17425982/212812246-51dc029c-e892-455d-86b4-946b5d03957a.png"/>
-performance
+YOLOv8 performance
 </div>
 
 <div align=center>
-<img src="https://user-images.githubusercontent.com/27466624/211974251-8de633c8-090c-47c9-ba52-4941dc9e3a48.jpg"/>
+<img src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
 YOLOv8-P5 model structure
 </div>
 

--- a/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -3,7 +3,7 @@
 ## 0 Introduction
 
 <div align=center >
-<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
+<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222869864-1955f054-aa6d-4a80-aed3-92f30af28849.jpg"/>
 Figure 1：YOLOv8-P5
 </div>
 

--- a/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -3,7 +3,7 @@
 ## 0 Introduction
 
 <div align=center >
-<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/211974251-8de633c8-090c-47c9-ba52-4941dc9e3a48.jpg"/>
+<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
 Figure 1：YOLOv8-P5
 </div>
 

--- a/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -3,7 +3,7 @@
 ## 0 简介
 
 <div align=center >
-<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/211974251-8de633c8-090c-47c9-ba52-4941dc9e3a48.jpg"/>
+<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
 图 1：YOLOv8-P5 模型结构
 </div>
 

--- a/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -3,7 +3,7 @@
 ## 0 简介
 
 <div align=center >
-<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222713096-565f8fbd-7962-458c-aef6-4ab38d0d6de3.jpg"/>
+<img alt="YOLOv8-P5_structure" src="https://user-images.githubusercontent.com/27466624/222869864-1955f054-aa6d-4a80-aed3-92f30af28849.jpg"/>
 图 1：YOLOv8-P5 模型结构
 </div>
 


### PR DESCRIPTION
## Motivation

Fix typos in the YOLOv8 diagram.

## Modification

Modify the channels after No.13 `Upsample` from 256 to 512, the channels after No.14 `Concat` from 512 to 768, and the channels after No.17 `Concat` from 512 to 768.

![YOLOv8_structure_MMYOLO_v1.3](https://user-images.githubusercontent.com/27466624/222869864-1955f054-aa6d-4a80-aed3-92f30af28849.jpg)
