### PR TITLE
Add gpu_assign_thr parameter to BatchTaskAlignedAssigner

### DIFF
--- a/tests/test_models/test_task_modules/test_assigners/test_batch_task_aligned_assigner.py
+++ b/tests/test_models/test_task_modules/test_assigners/test_batch_task_aligned_assigner.py
@@ -54,3 +54,29 @@ class TestBatchTaskAlignedAssigner(TestCase):
         self.assertEqual(assigned_scores.shape,
                          torch.Size([batch_size, 84, num_classes]))
         self.assertEqual(fg_mask_pre_prior.shape, torch.Size([batch_size, 84]))
+        # test cpu assigner
+        assigner_cpu = BatchTaskAlignedAssigner(
+            num_classes=num_classes,
+            alpha=1,
+            beta=6,
+            topk=13,
+            eps=1e-9,
+            gpu_assign_thr=1)
+
+        assign_result_cpu = assigner_cpu.forward(pred_bboxes, pred_scores,
+                                                 priors, gt_labels, gt_bboxes,
+                                                 pad_bbox_flag)
+
+        assigned_labels_cpu = assign_result_cpu['assigned_labels']
+        assigned_bboxes_cpu = assign_result_cpu['assigned_bboxes']
+        assigned_scores_cpu = assign_result_cpu['assigned_scores']
+        fg_mask_pre_prior_cpu = assign_result_cpu['fg_mask_pre_prior']
+
+        self.assertEqual(assigned_labels_cpu.shape,
+                         torch.Size([batch_size, 84]))
+        self.assertEqual(assigned_bboxes_cpu.shape,
+                         torch.Size([batch_size, 84, 4]))
+        self.assertEqual(assigned_scores_cpu.shape,
+                         torch.Size([batch_size, 84, num_classes]))
+        self.assertEqual(fg_mask_pre_prior_cpu.shape,
+                         torch.Size([batch_size, 84]))


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Add gpu_assign_thr parameter to BatchTaskAlignedAssigner to address OOM (out of memory) errors that can occur when there are a large number of bounding boxes to process. This parameter sets a threshold for the number of boxes assigned to a single GPU, which can help distribute the workload more evenly and prevent memory exhaustion.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
I added a parameter 'gpu_assign_thr' in BatchTaskAlignedAssigner's configuration, which can control the occurrence of out-of-memory errors when the number of bounding boxes in the assigner exceeds a certain value.
![image](https://user-images.githubusercontent.com/130134976/230588143-21f91198-1552-4845-ad15-c66efc2ab31c.png)

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
