### PR TITLE
[Bug fix] Fix get_file_list() not returning images with uppercase extension.

### DIFF
--- a/mmyolo/utils/misc.py
+++ b/mmyolo/utils/misc.py
@@ -72,7 +72,9 @@ def get_file_list(source_root: str) -> [list, dict]:
     source_file_path_list = []
     if is_dir:
         # when input source is dir
-        for file in scandir(source_root, IMG_EXTENSIONS, recursive=True):
+        for file in scandir(
+                source_root, IMG_EXTENSIONS, recursive=True,
+                case_sensitive=False):
             source_file_path_list.append(os.path.join(source_root, file))
     elif is_url:
         # when input source is url


### PR DESCRIPTION
## Motivation

When running `demo/demo_large_image.py` on a folder of images, no images were used for inference because the `get_file_list()` function in `mmyolo/utils/misc` does NOT read uppercase extension images when passing a folder as argument.

Example: `Image_001.JPG`, `Image_002.PNG` and `Image_003.TIFF` are NOT returned by the function, but they should. Many cameras output images with uppercase extensions (such as DJI drones, for example). We should not have to rename our images to be able to infer on them.

## Modification

Simple fix: Inside `get_file_list()`, I simply added the existing flag: `case_sensitive=False` to the `scandir()` function from `mmengine`.

## Impact

This PR simply allows users to use the `get_file_list()` function on folders that contain uppercase, lowercase, or mixed case image extensions.
