### PR TITLE
Fix the bug that sometimes the channel cannot be aligned in FPN

### DIFF
--- a/mmyolo/models/layers/yolo_bricks.py
+++ b/mmyolo/models/layers/yolo_bricks.py
@@ -1207,8 +1207,8 @@ class CSPResLayer(nn.Module):
         assert attention_cfg is None or isinstance(attention_cfg, dict)
 
         if stride == 2:
-            conv1_in_channels = conv2_in_channels = conv3_in_channels = (
-                in_channels + out_channels) // 2
+            conv1_in_channels = conv2_in_channels = (in_channels +
+                                                     out_channels) // 2
             blocks_channels = conv1_in_channels // 2
             self.conv_down = ConvModule(
                 in_channels,
@@ -1220,7 +1220,6 @@ class CSPResLayer(nn.Module):
                 act_cfg=act_cfg)
         else:
             conv1_in_channels = conv2_in_channels = in_channels
-            conv3_in_channels = out_channels
             blocks_channels = out_channels // 2
             self.conv_down = None
 
@@ -1241,7 +1240,7 @@ class CSPResLayer(nn.Module):
         self.blocks = self.build_blocks_layer(blocks_channels)
 
         self.conv3 = ConvModule(
-            conv3_in_channels,
+            blocks_channels * 2,
             out_channels,
             1,
             norm_cfg=norm_cfg,

--- a/mmyolo/models/necks/yolov5_pafpn.py
+++ b/mmyolo/models/necks/yolov5_pafpn.py
@@ -103,8 +103,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
 
         if idx == 1:
             return CSPLayer(
-                make_divisible(self.in_channels[idx - 1] * 2,
-                               self.widen_factor),
+                make_divisible(self.in_channels[idx - 1], self.widen_factor) *
+                2,
                 make_divisible(self.in_channels[idx - 1], self.widen_factor),
                 num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
                 add_identity=False,
@@ -113,8 +113,8 @@ class YOLOv5PAFPN(BaseYOLONeck):
         else:
             return nn.Sequential(
                 CSPLayer(
-                    make_divisible(self.in_channels[idx - 1] * 2,
-                                   self.widen_factor),
+                    make_divisible(self.in_channels[idx - 1],
+                                   self.widen_factor) * 2,
                     make_divisible(self.in_channels[idx - 1],
                                    self.widen_factor),
                     num_blocks=make_round(self.num_csp_blocks,
@@ -159,7 +159,7 @@ class YOLOv5PAFPN(BaseYOLONeck):
             nn.Module: The bottom up layer.
         """
         return CSPLayer(
-            make_divisible(self.in_channels[idx] * 2, self.widen_factor),
+            make_divisible(self.in_channels[idx], self.widen_factor) * 2,
             make_divisible(self.in_channels[idx + 1], self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,

--- a/mmyolo/models/necks/yolov6_pafpn.py
+++ b/mmyolo/models/necks/yolov6_pafpn.py
@@ -107,9 +107,9 @@ class YOLOv6RepPAFPN(BaseYOLONeck):
         block_cfg = self.block_cfg.copy()
 
         layer0 = RepStageBlock(
-            in_channels=int(
-                (self.out_channels[idx - 1] + self.in_channels[idx - 1]) *
-                self.widen_factor),
+            in_channels=sum(
+                map(lambda x: int(x * self.widen_factor),
+                    (self.out_channels[idx - 1], self.in_channels[idx - 1]))),
             out_channels=int(self.out_channels[idx - 1] * self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             block_cfg=block_cfg)
@@ -156,7 +156,7 @@ class YOLOv6RepPAFPN(BaseYOLONeck):
         block_cfg = self.block_cfg.copy()
 
         return RepStageBlock(
-            in_channels=int(self.out_channels[idx] * 2 * self.widen_factor),
+            in_channels=int(self.out_channels[idx] * self.widen_factor) * 2,
             out_channels=int(self.out_channels[idx + 1] * self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             block_cfg=block_cfg)
@@ -241,9 +241,9 @@ class YOLOv6CSPRepPAFPN(YOLOv6RepPAFPN):
         block_cfg = self.block_cfg.copy()
 
         layer0 = BepC3StageBlock(
-            in_channels=int(
-                (self.out_channels[idx - 1] + self.in_channels[idx - 1]) *
-                self.widen_factor),
+            in_channels=sum(
+                map(lambda x: int(x * self.widen_factor),
+                    (self.out_channels[idx - 1], self.in_channels[idx - 1]))),
             out_channels=int(self.out_channels[idx - 1] * self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             block_cfg=block_cfg,
@@ -276,7 +276,7 @@ class YOLOv6CSPRepPAFPN(YOLOv6RepPAFPN):
         block_cfg = self.block_cfg.copy()
 
         return BepC3StageBlock(
-            in_channels=int(self.out_channels[idx] * 2 * self.widen_factor),
+            in_channels=int(self.out_channels[idx] * self.widen_factor) * 2,
             out_channels=int(self.out_channels[idx + 1] * self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             block_cfg=block_cfg,

--- a/mmyolo/models/necks/yolov8_pafpn.py
+++ b/mmyolo/models/necks/yolov8_pafpn.py
@@ -74,8 +74,9 @@ class YOLOv8PAFPN(YOLOv5PAFPN):
             nn.Module: The top down layer.
         """
         return CSPLayerWithTwoConv(
-            make_divisible((self.in_channels[idx - 1] + self.in_channels[idx]),
-                           self.widen_factor),
+            sum(
+                map(lambda x: make_divisible(x, self.widen_factor),
+                    (self.in_channels[idx - 1], self.in_channels[idx]))),
             make_divisible(self.out_channels[idx - 1], self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,
@@ -92,9 +93,9 @@ class YOLOv8PAFPN(YOLOv5PAFPN):
             nn.Module: The bottom up layer.
         """
         return CSPLayerWithTwoConv(
-            make_divisible(
-                (self.out_channels[idx] + self.out_channels[idx + 1]),
-                self.widen_factor),
+            sum(
+                map(lambda x: make_divisible(x, self.widen_factor),
+                    (self.in_channels[idx + 1], self.in_channels[idx]))),
             make_divisible(self.out_channels[idx + 1], self.widen_factor),
             num_blocks=make_round(self.num_csp_blocks, self.deepen_factor),
             add_identity=False,


### PR DESCRIPTION
In YOLOv5, v6, v8, PPYOLOE, when the widen_factor is certain, the number of convolution input channels cannot be aligned with the corresponding feature map #781 