### PR TITLE
[Docs] Fix typo in English documentation

### DIFF
--- a/docs/en/get_started/installation.md
+++ b/docs/en/get_started/installation.md
@@ -15,7 +15,7 @@ If you are currently in the mmyolo project directory, you can use the following 
 
 ```shell
 cd mmyolo
-pip install -U openmom
+pip install -U openmim
 mim install -r requirements/mminstall.txt
 ```
 


### PR DESCRIPTION
## Motivation

Fix a typo in the documentation.

## Modification

- Fix a typo in `installation.md`, line 18: `openmom` to `openmim`

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
