### PR TITLE
Fix small typos in English installation instructions

### DIFF
--- a/docs/en/get_started/installation.md
+++ b/docs/en/get_started/installation.md
@@ -15,7 +15,7 @@ If you are currently in the mmyolo project directory, you can use the following 
 
 ```shell
 cd mmyolo
-pip install -U openmom
+pip install -U openmim
 mim install -r requirements/mminstall.txt
 ```
 
@@ -27,7 +27,7 @@ b. If you would like to use `albumentations`, we suggest using `pip install -r r
 
 **Step 1.** Install MMYOLO.
 
-Case a: If you develop and run mmdet directly, install it from source:
+Case a: If you develop and run mmyolo directly, install it from source:
 
 ```shell
 git clone https://github.com/open-mmlab/mmyolo.git


### PR DESCRIPTION
## Motivation

Make mmyolo installation easier for users.

## Modification

* `openmom` -> `openmim` package name fix in installation instructions
* `mmdet` was mistakenly used instead of `mmyolo` 

## BC-breaking (Optional)

Documentation-only change

## Use cases (Optional)

Documentation-only change

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
  * is this needed? How to run linters? 
3. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. :heavy_check_mark: 
4. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification. :heavy_check_mark: 
5. The documentation has been modified accordingly, like docstring or example tutorials. :heavy_check_mark: 
