### PR TITLE
Migrate QARepVGG from YOLOv6 to MMYOLO

### DIFF
--- a/configs/yolov6/qarepvgg/yolov6_v3_m_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
+++ b/configs/yolov6/qarepvgg/yolov6_v3_m_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
@@ -1,0 +1,5 @@
+_base_ = '../yolov6_v3_m_syncbn_fast_8xb32-300e_coco.py'
+
+model = dict(
+    backbone=dict(block_cfg=dict(type='QARepVGGBlockV2')),
+    neck=dict(block_cfg=dict(type='QARepVGGBlockV2')))

--- a/configs/yolov6/qarepvgg/yolov6_v3_n_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
+++ b/configs/yolov6/qarepvgg/yolov6_v3_n_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
@@ -1,0 +1,5 @@
+_base_ = '../yolov6_v3_n_syncbn_fast_8xb32-300e_coco.py'
+
+model = dict(
+    backbone=dict(block_cfg=dict(type='QARepVGGBlockV2')),
+    neck=dict(block_cfg=dict(type='QARepVGGBlockV2')))

--- a/configs/yolov6/qarepvgg/yolov6_v3_s_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
+++ b/configs/yolov6/qarepvgg/yolov6_v3_s_qarepvggv2_syncbn_fast_8xb32-300e_coco.py
@@ -1,0 +1,5 @@
+_base_ = '../yolov6_v3_s_syncbn_fast_8xb32-300e_coco.py'
+
+model = dict(
+    backbone=dict(block_cfg=dict(type='QARepVGGBlockV2')),
+    neck=dict(block_cfg=dict(type='QARepVGGBlockV2')))

--- a/demo/15_minutes_object_detection.ipynb
+++ b/demo/15_minutes_object_detection.ipynb
@@ -808,7 +808,7 @@
       },
       "outputs": [],
       "source": [
-        "!python projects/easydeploy/tools/export.py \\\n",
+        "!python projects/easydeploy/tools/export_onnx.py \\\n",
         "\t    configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \\\n",
         "\t    work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \\\n",
         "\t    --work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \\\n",
@@ -873,7 +873,7 @@
       },
       "outputs": [],
       "source": [
-        "!python projects/easydeploy/tools/export.py \\\n",
+        "!python projects/easydeploy/tools/export_onnx.py \\\n",
         "        configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \\\n",
         "        work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \\\n",
         "        --work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \\\n",

--- a/demo/15_minutes_object_detection.ipynb
+++ b/demo/15_minutes_object_detection.ipynb
@@ -842,7 +842,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "!python projects/easydeploy/tools/image-demo.py \\\n",
+        "!python projects/easydeploy/tools/image_demo.py \\\n",
         "        data/cat/images/IMG_20210728_205312.jpg \\\n",
         "        configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \\\n",
         "        work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.onnx \\\n",
@@ -941,7 +941,7 @@
         "└── yolov5_s-v61_fast_1xb12-40e_cat.py\n",
         "```\n",
         "\n",
-        "Let's continue use `image-demo.py` for image inference:"
+        "Let's continue use `image_demo.py` for image inference:"
       ]
     },
     {
@@ -958,7 +958,7 @@
       },
       "outputs": [],
       "source": [
-        "!python projects/easydeploy/tools/image-demo.py \\\n",
+        "!python projects/easydeploy/tools/image_demo.py \\\n",
         "        data/cat/images/IMG_20210728_205312.jpg \\\n",
         "        configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \\\n",
         "        work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.engine \\\n",

--- a/docs/en/get_started/15_minutes_object_detection.md
+++ b/docs/en/get_started/15_minutes_object_detection.md
@@ -432,7 +432,7 @@ pip install tensorrt        # If you have GPU environment and need to output Ten
 Once installed, you can use the following command to transform and deploy the trained model on the cat dataset with one click. The current ONNX version is 1.13.0 and TensorRT version is 8.5.3.1, so keep the `--opset` value of 11. The remaining parameters need to be adjusted according to the config used. Here we export the CPU version of ONNX with the `--backend` set to 1.
 
 ```shell
-python projects/easydeploy/tools/export.py \
+python projects/easydeploy/tools/export_onnx.py \
 	configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
 	work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \
 	--work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \
@@ -469,7 +469,7 @@ After successful inference, the result image will be generated in the `output` f
 Let's go on to convert the engine file for TensorRT, because TensorRT needs to be specific to the current environment and deployment version, so make sure to export the parameters, here we export the TensorRT8 file, the `--backend` is 2.
 
 ```shell
-python projects/easydeploy/tools/export.py \
+python projects/easydeploy/tools/export_onnx.py \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \
     --work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \

--- a/docs/en/get_started/15_minutes_object_detection.md
+++ b/docs/en/get_started/15_minutes_object_detection.md
@@ -453,7 +453,7 @@ On success, you will get the converted ONNX model under `work-dir`, which is nam
 Let's use `end2end.onnx` model to perform a basic image inference:
 
 ```shell
-python projects/easydeploy/tools/image-demo.py \
+python projects/easydeploy/tools/image_demo.py \
     data/cat/images/IMG_20210728_205312.jpg \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.onnx \
@@ -514,10 +514,10 @@ work_dirs/yolov5_s-v61_fast_1xb12-40e_cat
 └── yolov5_s-v61_fast_1xb12-40e_cat.py
 ```
 
-Let's continue use `image-demo.py` for image inference:
+Let's continue use `image_demo.py` for image inference:
 
 ```shell
-python projects/easydeploy/tools/image-demo.py \
+python projects/easydeploy/tools/image_demo.py \
     data/cat/images/IMG_20210728_205312.jpg \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.engine \

--- a/docs/en/recommended_topics/deploy/easydeploy_guide.md
+++ b/docs/en/recommended_topics/deploy/easydeploy_guide.md
@@ -1,1 +1,7 @@
 # EasyDeploy Deployment
+
+This project acts as a separate deployment project of MMYOLO, with the intention of divorcing the system of MMDeploy, and supporting the conversion and deployment functions of users once they finish the training of models, so as to reduce the learning and engineering costs of users.
+
+Currently, it supports the conversion of ONNX format and TensorRT format, and will support other inference platforms in the future.
+
+You can find more details about MMYOLO EasyDeploy in the [easydeploy document](../../../../projects/easydeploy/README.md).

--- a/docs/en/recommended_topics/deploy/mmdeploy_yolov5.md
+++ b/docs/en/recommended_topics/deploy/mmdeploy_yolov5.md
@@ -146,7 +146,7 @@ val_dataloader = dict(
 
 We use `allow_scale_up=False` to control when the input small images will be upsampled or not in the initialization of `LetterResize`. At the same time, the default `use_mini_pad=False` turns off the minimum padding strategy of the image, and `val_dataloader['dataset']` is passed in` batch_shapes_cfg=batch_shapes_cfg` to ensure that the minimum padding is performed according to the input size in `batch`. These configs will change the dimensions of the input image, so the converted model can support dynamic inputs according to the above dataset loader when testing.
 
-#### 2. Deployment Cofnig
+#### 2. Deployment Config
 
 To deploy the model to `ONNXRuntime`, please refer to the [`detection_onnxruntime_dynamic.py`](https://github.com/open-mmlab/mmyolo/blob/main/configs/deploy/detection_onnxruntime_dynamic.py) for more details.
 
@@ -271,11 +271,11 @@ python3 ${MMDEPLOY_DIR}/tools/deploy.py \
 
 When convert the model using the above commands, you will find the following files under the `work_dir` folder:
 
-![image](https://github.com/open-mmlab/mmdeploy/assets/110151316/760f3f7f-aa23-46cf-987c-717d3490246f)
+![image](https://github-production-user-asset-6210df.s3.amazonaws.com/110151316/242459821-760f3f7f-aa23-46cf-987c-717d3490246f.png)
 
 or
 
-![image](https://github.com/open-mmlab/mmdeploy/assets/110151316/732bcd9a-fca0-40ba-b5af-540a47eb9c35)
+![image](https://github-production-user-asset-6210df.s3.amazonaws.com/110151316/242460083-732bcd9a-fca0-40ba-b5af-540a47eb9c35.png)
 
 After exporting to `onnxruntime`, you will get six files as shown in Figure 1, where `end2end.onnx` represents the exported `onnxruntime` model. The `xxx.json` are the meta info for `MMDeploy SDK` inference.
 

--- a/docs/zh_cn/get_started/15_minutes_object_detection.md
+++ b/docs/zh_cn/get_started/15_minutes_object_detection.md
@@ -467,7 +467,7 @@ python projects/easydeploy/tools/image_demo.py \
 我们继续转换对应 TensorRT 的 engine 文件，因为 TensorRT 需要对应当前环境以及部署使用的版本进行，所以一定要确认导出参数，这里我们导出对应 TensorRT8 版本的文件，`--backend` 为 2。
 
 ```shell
-python projects/easydeploy/tools/export.py \
+python projects/easydeploy/tools/export_onnx.py \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/epoch_40.pth \
     --work-dir work_dirs/yolov5_s-v61_fast_1xb12-40e_cat \

--- a/docs/zh_cn/get_started/15_minutes_object_detection.md
+++ b/docs/zh_cn/get_started/15_minutes_object_detection.md
@@ -451,7 +451,7 @@ python projects/easydeploy/tools/export_onnx.py \
 接下来我们使用此 `end2end.onnx` 模型来进行一个基本的图片推理:
 
 ```shell
-python projects/easydeploy/tools/image-demo.py \
+python projects/easydeploy/tools/image_demo.py \
     data/cat/images/IMG_20210728_205117.jpg \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.onnx \
@@ -512,10 +512,10 @@ work_dirs/yolov5_s-v61_fast_1xb12-40e_cat
 └── yolov5_s-v61_fast_1xb12-40e_cat.py
 ```
 
-我们继续使用 `image-demo.py` 进行图片推理：
+我们继续使用 `image_demo.py` 进行图片推理：
 
 ```shell
-python projects/easydeploy/tools/image-demo.py \
+python projects/easydeploy/tools/image_demo.py \
     data/cat/images/IMG_20210728_205312.jpg \
     configs/yolov5/yolov5_s-v61_fast_1xb12-40e_cat.py \
     work_dirs/yolov5_s-v61_fast_1xb12-40e_cat/end2end.engine \

--- a/docs/zh_cn/recommended_topics/deploy/easydeploy_guide.md
+++ b/docs/zh_cn/recommended_topics/deploy/easydeploy_guide.md
@@ -3,3 +3,5 @@
 本项目作为 MMYOLO 的部署 project 单独存在，意图剥离 MMDeploy 当前的体系，独自支持用户完成模型训练后的转换和部署功能，使用户的学习和工程成本下降。
 
 当前支持对 ONNX 格式和 TensorRT 格式的转换，后续对其他推理平台也会支持起来。
+
+更多内容可前往 [EasyDeploy 文档](../../../../projects/easydeploy/README_zh-CN.md) 查看。

--- a/mmyolo/models/layers/__init__.py
+++ b/mmyolo/models/layers/__init__.py
@@ -4,13 +4,15 @@ from .yolo_bricks import (BepC3StageBlock, BiFusion, CSPLayerWithTwoConv,
                           DarknetBottleneck, EELANBlock, EffectiveSELayer,
                           ELANBlock, ImplicitA, ImplicitM,
                           MaxPoolAndStrideConvBlock, PPYOLOEBasicBlock,
-                          RepStageBlock, RepVGGBlock, SPPFBottleneck,
-                          SPPFCSPBlock, TinyDownSampleBlock)
+                          QARepVGGBlock, QARepVGGBlockV2, RepStageBlock,
+                          RepVGGBlock, SPPFBottleneck, SPPFCSPBlock,
+                          TinyDownSampleBlock)
 
 __all__ = [
     'SPPFBottleneck', 'RepVGGBlock', 'RepStageBlock', 'ExpMomentumEMA',
     'ELANBlock', 'MaxPoolAndStrideConvBlock', 'SPPFCSPBlock',
     'PPYOLOEBasicBlock', 'EffectiveSELayer', 'TinyDownSampleBlock',
     'EELANBlock', 'ImplicitA', 'ImplicitM', 'BepC3StageBlock',
-    'CSPLayerWithTwoConv', 'DarknetBottleneck', 'BiFusion'
+    'CSPLayerWithTwoConv', 'DarknetBottleneck', 'BiFusion', 'QARepVGGBlock',
+    'QARepVGGBlockV2'
 ]

--- a/mmyolo/utils/misc.py
+++ b/mmyolo/utils/misc.py
@@ -7,17 +7,19 @@ import torch
 from mmengine.utils import scandir
 from prettytable import PrettyTable
 
-from mmyolo.models import RepVGGBlock
+from mmyolo.models import QARepVGGBlock, QARepVGGBlockV2, RepVGGBlock
 
 IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif',
                   '.tiff', '.webp')
+DEPLOYABLE_ALGOS = (RepVGGBlock, QARepVGGBlock, QARepVGGBlockV2)
 
 
 def switch_to_deploy(model):
     """Model switch to deploy status."""
     for layer in model.modules():
-        if isinstance(layer, RepVGGBlock):
-            layer.switch_to_deploy()
+        for block in DEPLOYABLE_ALGOS:
+            if isinstance(layer, block):
+                layer.switch_to_deploy()
 
     print('Switch model to deploy modality.')
 

--- a/projects/easydeploy/docs/model_convert.md
+++ b/projects/easydeploy/docs/model_convert.md
@@ -42,7 +42,7 @@
 例子:
 
 ```shell
-python ./projects/easydeploy/tools/export.py \
+python ./projects/easydeploy/tools/export_onnx.py \
 	configs/yolov5/yolov5_s-v61_syncbn_fast_8xb16-300e_coco.py \
 	yolov5s.pth \
 	--work-dir work_dir \

--- a/projects/easydeploy/examples/main_onnxruntime.py
+++ b/projects/easydeploy/examples/main_onnxruntime.py
@@ -37,7 +37,7 @@ def parse_args():
     parser = ArgumentParser()
     parser.add_argument(
         'img', help='Image path, include image file, dir and URL.')
-    parser.add_argument('onnx', type=str, help='Onnx file')
+    parser.add_argument('onnx', type=str, help='Exported onnx file')
     parser.add_argument('--type', type=str, help='Model type')
     parser.add_argument(
         '--img-size',

--- a/projects/easydeploy/tools/image_demo.py
+++ b/projects/easydeploy/tools/image_demo.py
@@ -16,11 +16,28 @@ from mmengine.utils import ProgressBar, path
 from mmyolo.utils import register_all_modules
 from mmyolo.utils.misc import get_file_list
 
+# if you are using a custom dataset and you did not add class names
+# into your model config file, feel free to modify this part if necessary.
+CLASS_NAMES = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
+               'train', 'truck', 'boat', 'traffic light', 'fire hydrant',
+               'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
+               'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe',
+               'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
+               'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
+               'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
+               'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
+               'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
+               'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
+               'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop',
+               'mouse', 'remote', 'keyboard', 'cell phone', 'microwave',
+               'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock',
+               'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush')
+
 
 def parse_args():
     parser = ArgumentParser()
     parser.add_argument(
-        'img', help='Image path, include image file, dir and URL.')
+        'img', help='Image path, supports image file, dir and URL.')
     parser.add_argument('config', help='Config file')
     parser.add_argument('checkpoint', help='Checkpoint file')
     parser.add_argument(
@@ -74,7 +91,8 @@ def main():
     model.to(args.device)
 
     cfg = Config.fromfile(args.config)
-    class_names = cfg.get('class_name')
+    class_names = CLASS_NAMES if cfg.get('class_name') is None else cfg.get(
+        'class_name')
 
     test_pipeline = get_test_pipeline_cfg(cfg)
     test_pipeline[0] = ConfigDict({'type': 'mmdet.LoadImageFromNDArray'})
@@ -127,19 +145,16 @@ def main():
             bbox = bbox.tolist()
             color = colors[label]
 
-            if class_names is not None:
-                label_name = class_names[label]
-                name = f'cls:{label_name}_score:{score:0.4f}'
-            else:
-                name = f'cls:{label}_score:{score:0.4f}'
+            label_name = class_names[label]
+            name = f'{label_name}: {score:.2f}'
 
             cv2.rectangle(bgr, bbox[:2], bbox[2:], color, 2)
             cv2.putText(
                 bgr,
                 name, (bbox[0], bbox[1] - 2),
                 cv2.FONT_HERSHEY_SIMPLEX,
-                2.0, [225, 255, 255],
-                thickness=3)
+                1.0, [225, 255, 255],
+                thickness=2)
 
         if args.show:
             mmcv.imshow(bgr, 'result', 0)


### PR DESCRIPTION
## Motivation

Migrate the QARepVGG implementation from the official YOLOv6 repository and the deployment process using both the easydeploy and MMDeploy.

## Modification

configs/yolov6/qarepvgg/*
mmyolo/models/layers/__init__.py
mmyolo/models/layers/yolo_bricks.py
mmyolo/utils/misc.py
projects/easydeploy/

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
