### PR TITLE
fix fx tracer to support alpha in RepVGGBlock

### DIFF
--- a/mmyolo/models/layers/yolo_bricks.py
+++ b/mmyolo/models/layers/yolo_bricks.py
@@ -183,6 +183,7 @@ class RepVGGBlock(nn.Module):
         else:
             self.se = nn.Identity()
 
+        self.use_alpha = use_alpha
         if use_alpha:
             alpha = torch.ones([
                 1,
@@ -246,7 +247,7 @@ class RepVGGBlock(nn.Module):
             id_out = 0
         else:
             id_out = self.rbr_identity(inputs)
-        if self.alpha:
+        if self.use_alpha:
             return self.nonlinearity(
                 self.se(
                     self.rbr_dense(inputs) +
@@ -265,7 +266,7 @@ class RepVGGBlock(nn.Module):
         kernel3x3, bias3x3 = self._fuse_bn_tensor(self.rbr_dense)
         kernel1x1, bias1x1 = self._fuse_bn_tensor(self.rbr_1x1)
         kernelid, biasid = self._fuse_bn_tensor(self.rbr_identity)
-        if self.alpha:
+        if self.use_alpha:
             return kernel3x3 + self.alpha * self._pad_1x1_to_3x3_tensor(
                 kernel1x1) + kernelid, bias3x3 + self.alpha * bias1x1 + biasid
         else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Can't fx.trace with PPYOLOECSPResNet when use_alpha=True

minimal reproducible script.

```py
from mmrazor.models.task_modules.tracer.channel_analyzer import ChannelAnalyzer
from mmrazor.implementations.pruning.group_fisher import GroupFisherChannelMutator
from mmyolo.models.backbones import PPYOLOECSPResNet
from torch.fx import symbolic_trace

normalization_type='act'
analyzer=ChannelAnalyzer(tracer_type='FxTracer')
mutator=GroupFisherChannelMutator(channel_unit_cfg=dict(type='GroupFisherChannelUnit', default_args=dict(normalization_type=normalization_type)), parse_cfg=dict(type='ChannelAnalyzer', tracer_type='FxTracer'))
#  model=ResNet(depth=18)
deepen_factor = 0.33
widen_factor = 0.5
model=PPYOLOECSPResNet(
        deepen_factor=deepen_factor,
        widen_factor=widen_factor,
        block_cfg=dict(
            type='PPYOLOEBasicBlock', shortcut=True, use_alpha=True),
        norm_cfg=dict(type='BN', momentum=0.1, eps=1e-5),
        act_cfg=dict(type='SiLU', inplace=True),
        attention_cfg=dict(
            type='EffectiveSELayer', act_cfg=dict(type='HSigmoid')),
        use_large_stem=True)
print(model)
module=symbolic_trace(model)
```

## Modification

don't use traced tensor in the control flow 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
