### PR TITLE
[Fix] find_unused_parameters error

### DIFF
--- a/mmyolo/models/backbones/base_backbone.py
+++ b/mmyolo/models/backbones/base_backbone.py
@@ -118,6 +118,8 @@ class BaseBackbone(BaseModule, metaclass=ABCMeta):
                 stage += self.make_stage_plugins(plugins, idx, setting)
             self.add_module(f'stage{idx + 1}', nn.Sequential(*stage))
             self.layers.append(f'stage{idx + 1}')
+            
+        self._freeze_stages()
 
     @abstractmethod
     def build_stem_layer(self):

--- a/mmyolo/models/backbones/base_backbone.py
+++ b/mmyolo/models/backbones/base_backbone.py
@@ -118,7 +118,7 @@ class BaseBackbone(BaseModule, metaclass=ABCMeta):
                 stage += self.make_stage_plugins(plugins, idx, setting)
             self.add_module(f'stage{idx + 1}', nn.Sequential(*stage))
             self.layers.append(f'stage{idx + 1}')
-            
+
         self._freeze_stages()
 
     @abstractmethod


### PR DESCRIPTION
## Motivation

Solve the problem：

> RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one. This error indicate s that your module has parameters that were not used in producing loss. You can enable unused parameter detection by passing the keyword argument `find_unused_parameters=True` to `torch.nn.parallel.DistributedDataParallel`, and by making sure all `forward` function outputs participate in calculating loss.

## Modification

Adding self._freeze_stages() at the end of the backbone __init__ methods, similar to the [resnet code](https://github.com/open-mmlab/mmdetection/blob/main/mmdet/models/backbones/resnet.py#L489) ([here for swin](https://github.com/open-mmlab/mmdetection/blob/main/mmdet/models/backbones/swin.py#L643) and [here for CSPNeXt](https://github.com/open-mmlab/mmdetection/blob/main/mmdet/models/backbones/cspnext.py#L171)).

## reference:
https://github.com/open-mmlab/mmdetection/issues/8208#issuecomment-1505112163

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
4. The documentation has been modified accordingly, like docstring or example tutorials.
