### PR TITLE
[Docs] Fix Broken Internal Links in MMYOLO zh_CN/en Docs

### DIFF
--- a/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/en/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -42,7 +42,7 @@ The following table shows the official results of mAP, number of parameters and 
 
 It is worth mentioning that the recent YOLO series have shown significant performance improvements on the COCO dataset. However, their generalizability on custom datasets has not been extensively tested, which thereby will be a focus in the future development of MMYOLO.
 
-Before reading this article, if you are not familiar with YOLOv5, YOLOv6 and RTMDet, you can read the detailed explanation of [YOLOv5 and its implementation](https://mmyolo.readthedocs.io/en/latest/algorithm_descriptions/yolov5_description.html).
+Before reading this article, if you are not familiar with YOLOv5, YOLOv6 and RTMDet, you can read the detailed explanation of [YOLOv5 and its implementation](yolov5_description.md).
 
 ## 1 YOLOv8 Overview
 
@@ -133,7 +133,7 @@ Figure 8：results
 
 The above visualization result can be obtained by running the [browse_dataset](https://github.com/open-mmlab/mmyolo/blob/dev/tools/analysis_tools/browse_dataset.py) script.
 
-As the data augmentation process utilized in YOLOv8 is similar to YOLOv5, we will not delve into the specifics within this article. For a more in-depth understanding of each data transformation, we recommend reviewing the [YOLOv5 algorithm analysis document](https://mmyolo.readthedocs.io/en/latest/algorithm_descriptions/yolov5_description.html#id2) in MMYOLO.
+As the data augmentation process utilized in YOLOv8 is similar to YOLOv5, we will not delve into the specifics within this article. For a more in-depth understanding of each data transformation, we recommend reviewing the [YOLOv5 algorithm analysis document](yolov5_description.md) in MMYOLO.
 
 ## 5 Training strategy
 
@@ -238,4 +238,4 @@ In summary, YOLOv8 is a highly efficient algorithm that incorporates image class
 
 MMYOLO open source address for YOLOV8 [this](https://github.com/open-mmlab/mmyolo/blob/dev/configs/yolov8/)
 
-MMYOLO Algorithm Analysis Tutorial address is [yolov5_description](https://mmyolo.readthedocs.io/en/latest/algorithm_descriptions/yolov5_description.html)
+MMYOLO Algorithm Analysis Tutorial address is [yolov5_description](yolov5_description.md)

--- a/docs/en/recommended_topics/labeling_to_deployment_tutorials.md
+++ b/docs/en/recommended_topics/labeling_to_deployment_tutorials.md
@@ -10,7 +10,7 @@ The video of this document has been posted on Bilibili: [A nanny level tutorials
 All instructions in this document are done on Linux and are fully available on Windows, only slightly different in commands and operations.
 ```
 
-Default that you have completed the installation of MMYOLO, if not installed, please refer to the document [GET STARTED](https://mmyolo.readthedocs.io/en/latest/get_started.html) for installation.
+Default that you have completed the installation of MMYOLO, if not installed, please refer to the document [GET STARTED](https://mmyolo.readthedocs.io/en/latest/index.html), since Prerequisites section for installation.
 
 In this tutorial, we will introduce the whole process from annotating custom dataset to final training, testing and deployment. The overview steps are as below:
 

--- a/docs/en/tutorials/config.md
+++ b/docs/en/tutorials/config.md
@@ -1,6 +1,6 @@
 # Learn about Configs with YOLOv5
 
-MMYOLO and other OpenMMLab repositories use [MMEngine's config system](https://mmengine.readthedocs.io/en/latest/tutorials/config.html). It has a modular and inheritance design, which is convenient to conduct various experiments.
+MMYOLO and other OpenMMLab repositories use [MMEngine's config system](https://mmengine.readthedocs.io/en/latest/advanced_tutorials/config.html). It has a modular and inheritance design, which is convenient to conduct various experiments.
 
 ## Config file content
 

--- a/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
+++ b/docs/zh_cn/recommended_topics/algorithm_descriptions/yolov8_description.md
@@ -37,9 +37,9 @@ YOLOv8 是 Ultralytics 公司在 2023 年 1月 10 号开源的 YOLOv5 的下一�
 
 阅读本文前，如果你对 YOLOv5、YOLOv6 和 RTMDet 不熟悉，可以先看下如下文档：
 
-1. [YOLOv5 原理和实现全解析](https://mmyolo.readthedocs.io/zh_CN/latest/algorithm_descriptions/yolov5_description.html)
-2. [YOLOv6 原理和实现全解析](https://mmyolo.readthedocs.io/zh_CN/latest/algorithm_descriptions/yolov6_description.html)
-3. [RTMDet 原理和实现全解析](https://mmyolo.readthedocs.io/zh_CN/latest/algorithm_descriptions/rtmdet_description.html)
+1. [YOLOv5 原理和实现全解析](yolov5_description.md)
+2. [YOLOv6 原理和实现全解析](yolov6_description.md)
+3. [RTMDet 原理和实现全解析](rtmdet_description.md)
 
 ## 1 YOLOv8 概述
 
@@ -129,7 +129,7 @@ Loss 计算包括 2 个分支： **分类和回归分支，没有了之前的 ob
 图 7：results
 </div>
 
-上述效果可以运行 [browse_dataset](https://github.com/open-mmlab/mmyolo/blob/dev/tools/analysis_tools/browse_dataset.py) 脚本得到。由于每个 pipeline 都是比较常规的操作，本文不再赘述。如果想了解每个 pipeline 的细节，可以查看 MMYOLO 中 [YOLOv5 的算法解析文档](https://mmyolo.readthedocs.io/zh_CN/latest/algorithm_descriptions/yolov5_description.html#id2) 。
+上述效果可以运行 [browse_dataset](https://github.com/open-mmlab/mmyolo/blob/dev/tools/analysis_tools/browse_dataset.py) 脚本得到。由于每个 pipeline 都是比较常规的操作，本文不再赘述。如果想了解每个 pipeline 的细节，可以查看 MMYOLO 中 [YOLOv5 的算法解析文档](yolov5_description.md) 。
 
 ## 5 训练策略
 
@@ -241,4 +241,4 @@ python demo/featmap_vis_demo.py demo/demo.jpg configs/yolov8/yolov8_s_syncbn_fas
 
 MMYOLO 开源地址： https://github.com/open-mmlab/mmyolo/blob/dev/configs/yolov8/README.md
 
-MMYOLO 算法解析教程：https://mmyolo.readthedocs.io/zh_CN/latest/algorithm_descriptions/index.html#id2
+MMYOLO 算法解析教程：https://mmyolo.readthedocs.io/zh-cn/latest/recommended_topics/algorithm_descriptions/index.html

--- a/docs/zh_cn/recommended_topics/labeling_to_deployment_tutorials.md
+++ b/docs/zh_cn/recommended_topics/labeling_to_deployment_tutorials.md
@@ -10,7 +10,7 @@
 本教程所有指令是在 Linux 上面完成，Windows 也是完全可用的，但是命令和操作稍有不同。
 ```
 
-本教程默认您已经完成 MMYOLO 的安装，如果未安装，请参考文档 [开始你的第一步](https://mmyolo.readthedocs.io/zh_CN/latest/get_started.html#id1) 进行安装。
+本教程默认您已经完成 MMYOLO 的安装，如果未安装，请参考文档 [开启MMYOLO之旅](https://mmyolo.readthedocs.io/zh-cn/latest/index.html)，从依赖一节开始进行安装。
 
 本教程涵盖从 用户自定义图片数据集标注 到 最终进行训练和部署 的整体流程。步骤概览如下：
 

--- a/docs/zh_cn/tutorials/config.md
+++ b/docs/zh_cn/tutorials/config.md
@@ -1,6 +1,6 @@
 # 学习 YOLOv5 配置文件
 
-MMYOLO 和其他 OpenMMLab 仓库使用 [MMEngine 的配置文件系统](https://mmengine.readthedocs.io/zh_cn/latest/tutorials/config.md)。 配置文件使用了模块化和继承设计，以便于进行各类实验。
+MMYOLO 和其他 OpenMMLab 仓库使用 [MMEngine 的配置文件系统](https://mmengine.readthedocs.io/zh-cn/latest/advanced_tutorials/config.html)。 配置文件使用了模块化和继承设计，以便于进行各类实验。
 
 ## 配置文件的内容
 


### PR DESCRIPTION
## Motivation

While browsing and reviewing the MMYOLO documentation, I encountered some broken internal links that hindered readers from navigating the pages smoothly. Therefore, I have fixed these broken links and hope you will consider incorporating my changes.

## Modification

Fixed the issue of broken links in the `docs/en and zh_CN/recommended_topics/algorithm_descriptions/yolov8_description.md`, which were supposed to navigate to the YOLOv5, YOLOv6, and RTMDet ALGORITHM PRINCIPLES AND IMPLEMENTATION documents.

Fixed the issue of broken links in the `docs/en and zh_CN/recommended_topics/labeling_to_deployment_tutorials.md` , specifically the MMYOLO installation guide link.

Fixed the issue of broken links in the `docs/en and zh_CN/tutorials/config.md`, particularly the link to the MMEngine Configuration File System.

## Use cases (Optional)

<img width="1589" alt="image" src="https://github.com/open-mmlab/mmyolo/assets/49088507/027c1a37-b692-4b72-9ff3-54a3ab20f03a">
My modified documents can be successfully rendered, and the previously broken links now navigate correctly.

## Checklist

1. Pre-commit or other linting tools are used to fix potential lint issues.    Yes✅
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.    Yes✅
3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.    Yes✅
4. The documentation has been modified accordingly, like docstring or example tutorials.    Yes✅
