### PR TITLE
[feature] bump max mmcv version

### DIFF
--- a/mmyolo/__init__.py
+++ b/mmyolo/__init__.py
@@ -7,7 +7,7 @@ from mmengine.utils import digit_version
 from .version import __version__, version_info
 
 mmcv_minimum_version = '2.0.0rc4'
-mmcv_maximum_version = '2.1.0'
+mmcv_maximum_version = '2.3.0'
 mmcv_version = digit_version(mmcv.__version__)
 
 mmengine_minimum_version = '0.7.1'


### PR DESCRIPTION
## Motivation

Make MMYolo compatible with newer PyTorch versions by adding support for MMCV 2.2.0.
MMDetection has [already implemented this change](https://github.com/open-mmlab/mmdetection/pull/11680/files). I've experienced no issues using MMYolo with MMCV 2.2.0 so far.

## Modification

Adds support for MMCV versions 2.1 and 2.2

## Checklist

- [x] 1. Pre-commit or other linting tools are used to fix potential lint issues.
- [x] 2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] 3. If the modification has a potential influence on downstream projects, this PR should be tested with downstream projects, like MMDetection or MMClassification.
- [x] 4. The documentation has been modified accordingly, like docstring or example tutorials.
