### PR TITLE
[FIX] issue 1038, fix Key img_path error under wrong albumentation version

### DIFF
--- a/requirements/albu.txt
+++ b/requirements/albu.txt
@@ -1,1 +1,1 @@
-albumentations --no-binary qudida,albumentations
+albumentations==1.3.1 --no-binary qudida,albumentations


### PR DESCRIPTION
## Motivation

this commit fixes the problem when a new version of albumentation like `1.4.8` is installed, the training process would throw a "ValueError: Key img_path is not in available keys. " error.

## Modification

requirements/albu.txt was changed and strict version `1.3.1` was assigned to albumentation package.
